### PR TITLE
fix: Jobs GUI improvement

### DIFF
--- a/src/features/jobs/routes.go
+++ b/src/features/jobs/routes.go
@@ -10,6 +10,7 @@ func RegisterRoutes(app *fiber.App, service *Service) {
 	ui.Get("/list", handler.HandleAllJobsList)
 	ui.Get("/latest", handler.HandleLatestJobs)
 	ui.Post("/clear-finished", handler.HandleClearFinishedJobs)
+	ui.Get("/active-count", handler.HandleActiveJobsCount)
 
 	// ui.Post("/cleanup", handler.HandleCleanupJobs)
 	jobs.Get("/", handler.HandleJobList)

--- a/views/partials/job_status.html
+++ b/views/partials/job_status.html
@@ -1,0 +1,10 @@
+<!-- This template is currently not in use but the idea, is that if at some point we want to display the active jobs somewhere in the app in all sections
+we could do something like {{template "job_status" .}} in main.html, for example and we will be able to see them.-->
+{{define "job_status"}}
+  <div id="app-status" 
+       hx-get="/ui/jobs/active" 
+       hx-trigger="load, jobStarted from:body, every 5s" 
+       hx-target="this" 
+       hx-swap="innerHTML">
+  </div>
+{{end}}

--- a/views/partials/main.html
+++ b/views/partials/main.html
@@ -16,7 +16,6 @@
         <!-- end Navbar -->
         <!-- Main -->
         <div class="m-2 sm:m-8">
-        {{template "status" .}}
            <div id="toast-container" class="fixed top-5 right-5 z-50"></div>
             <div class="p-4 border-2 border-gray-300 dark:border-gray-500 border-dashed rounded-lg dark:border-gray-700 mt-0">
             <div id="contenido">

--- a/views/partials/navbar.html
+++ b/views/partials/navbar.html
@@ -87,6 +87,14 @@
                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
              </svg>
                <span class="mx-4">Jobs</span>
+              <div id="active-jobs-badge"
+                  hx-get="/ui/jobs/active-count"
+                  hx-push-url="false"
+                  hx-trigger="load, every 1s, refreshActiveJobsBadge from:body"
+                  hx-target="#active-jobs-count-nav"
+                  hx-swap="innedHTML">
+                <span id="active-jobs-count-nav" class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-blue-300 dark:drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]">(0)</span>
+              </div>
              </a>
            </button>
          </li>

--- a/views/partials/sidebar.html
+++ b/views/partials/sidebar.html
@@ -100,10 +100,18 @@
              hx-target="#contenido"
              class="sidebtn hover:outline outline-gray-600 dark:outline-none flex items-center px-4 py-2 mt-5 text-gray-600 transition-colors duration-200 transform rounded-md dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-neutral-800 dark:hover:text-gray-200 hover:text-gray-700 dark:focus:bg-neutral-700 dark:focus:text-cyan-300 dark:hover:text-cyan-400 dark:focus:shadow-[inset_0_0_10px_rgba(0,255,255,0.2)] focus:outline-none cursor-pointer"
            >
-             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
-               <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
-             </svg>
-              <span class="mx-4">Jobs</span>
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 7.5l3 2.25-3 2.25m4.5 0h3m-9 8.25h13.5A2.25 2.25 0 0 0 21 18V6a2.25 2.25 0 0 0-2.25-2.25H5.25A2.25 2.25 0 0 0 3 6v12a2.25 2.25 0 0 0 2.25 2.25Z" />
+              </svg>
+                <span class="mx-4 mr-2">Jobs</span>
+                <div id="active-jobs-badge"
+                     hx-get="/ui/jobs/active-count"
+                     hx-push-url="false"
+                     hx-trigger="load, every 1s, refreshActiveJobsBadge from:body"
+                     hx-target="#active-jobs-count"
+                     hx-swap="innedHTML">
+                  <span id="active-jobs-count" class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-blue-300 dark:drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]">(0)</span>
+                </div>
             </a>
           </button>
          </li>

--- a/views/partials/status.html
+++ b/views/partials/status.html
@@ -1,8 +1,0 @@
-{{define "status"}}
-  <div id="app-status" 
-       hx-get="/ui/jobs/active" 
-       hx-trigger="load, jobStarted from:body, every 5s" 
-       hx-target="this" 
-       hx-swap="innerHTML">
-  </div>
-{{end}}

--- a/views/sections/download.html
+++ b/views/sections/download.html
@@ -21,34 +21,7 @@
       </div>
     </div>
   </div>
-  <span class="htmx-indicator-off">Search</span>
-
-  <!-- Search Results -->
   <div id="search-results">
-    <div
-      class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4"
-    >
-      <button
-        _="on click put 'block' into #homepage-content.style.display then put 'none' into #search-results.style.display"
-        class="text-purple-600 hover:text-purple-700 dark:text-purple-400 dark:hover:text-purple-300 flex items-center gap-2"
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="size-4"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18"
-          />
-        </svg>
-        Back to Home
-      </button>
-    </div>
     <h3 class="text-lg font-medium text-slate-800 dark:text-white mb-4">
       Search Results
     </h3>


### PR DESCRIPTION
improves jobs ui so it does not render in every site (left the view just in case) plus added a count of active jobs to the sidebar
Sidebar:
<img width="279" height="139" alt="image" src="https://github.com/user-attachments/assets/2b77d0a9-0612-4242-91a0-f39337b22fa8" />
Navbar:
<img width="193" height="89" alt="image" src="https://github.com/user-attachments/assets/591ad4ca-2ebc-48c6-a46b-b944848c566e" />


Additional changes: 
* Clean up download view.


Good Example: 
* This is a good example to update UI components with HX-Headers sent from the back.
* This is also a good example of how we keep our Services minimal, not adding a Count method to the service but using the Getjobs and counting it in the HTTP presenter with a new handler. 