### PR TITLE
feat: paths

### DIFF
--- a/src/features/config/loader.go
+++ b/src/features/config/loader.go
@@ -120,11 +120,11 @@ func createDefaultConfig() *Config {
 			Duplicates:       "queue",
 			AutoStartWatcher: false,
 			PathOptions: Paths{
-				Compilations:    "%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
-				AlbumSoundtrack: "%asciify{$albumartist}/%asciify{$album} [OST] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
-				AlbumSingle:     "%asciify{$albumartist}/%asciify{$album} [Single] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
-				AlbumEP:         "%asciify{$albumartist}/%asciify{$album} [EP] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
-				DefaultPath:     "%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
+				Compilations:    "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
+				AlbumSoundtrack: "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} [OST] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
+				AlbumSingle:     "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} [Single] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
+				AlbumEP:         "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} [EP] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
+				DefaultPath:     "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
 			},
 		},
 		Metadata: Metadata{

--- a/src/infra/files/path_parser.go
+++ b/src/infra/files/path_parser.go
@@ -121,6 +121,10 @@ func (p *TemplatePathParser) renderValues(template string, track *music.Track) (
 			val = fmt.Sprintf("%02d", track.Metadata.TrackNumber)
 		case "title":
 			val = track.Title
+		case "format":
+			val = track.Format
+		case "genre":
+			val = track.Metadata.Genre
 		default:
 			return raw // Unknown placeholder
 		}

--- a/src/music/album.go
+++ b/src/music/album.go
@@ -47,6 +47,7 @@ type Album struct {
 	ImageXL     string
 	ArtworkData []byte
 	Genre       string
+	Genres      []string
 }
 
 // Validate validates the album fields.
@@ -92,3 +93,4 @@ func (a *Album) Validate() error {
 	}
 	return nil
 }
+

--- a/views/config/config_form.html
+++ b/views/config/config_form.html
@@ -303,12 +303,15 @@
         </div>
       </div>
 
-    <!-- Path Templates (Full Width) -->
-      <div class="bg-white/80 dark:bg-gray-900/70 p-4 rounded-lg shadow-lg backdrop-blur-sm border border-gray-200/50 dark:border-gray-800/70">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
-          <i class="fas fa-folder-tree text-indigo-500 text-lg"></i>
-          Path Templates
-        </h2>
+     <!-- Path Placeholders  -->
+       <div class="bg-white/80 dark:bg-gray-900/70 p-4 rounded-lg shadow-lg backdrop-blur-sm border border-gray-200/50 dark:border-gray-800/70">
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+            <i class="fas fa-folder-tree text-indigo-500 text-lg"></i>
+            Path Placeholders
+            <a href="https://soulsolid.contre.io/docs/paths/#available-placeholders" target="_blank" class="text-blue-600 hover:text-blue-500 text-xs ml-2">
+              (docs)
+            </a>
+          </h2>
         <div class="grid grid-cols-1 gap-3">
          <div class="p-3 bg-gray-50/50 dark:bg-gray-700/30 rounded-lg">
            <label for="import.paths.default_path" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">Default Path</label>


### PR DESCRIPTION
Add support for `genre` and `tracks`.
Updated docs here as well: https://soulsolid.contre.io/docs/paths/#available-placeholders

```
./music_library
└── Alternativo
    └── flac
        └── LUX (2025)
            ├── 04 Porcelana.flac
            └── 07 La Perla.flac

4 directories, 2 files
```

Solves #72 
