### PR TITLE
feat: Migrating from bookworm to alpine

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
-FROM golang:bookworm AS app-builder
+FROM golang:1.25-alpine AS app-builder
 ARG IMAGE_TAG
 ENV CGO_ENABLED=2
-RUN apt-get update && apt-get install -y gcc libc-dev libsqlite3-dev nodejs npm git
+RUN apk add --no-cache go gcc libc-dev sqlite-dev nodejs npm git
 WORKDIR /app
 # Copy your source code here - adjust the path as needed
 ADD . .
@@ -10,10 +10,10 @@ RUN go mod tidy
 # Build without static linking for plugin compatibility
 RUN go build -o /app/soulsolid src/main.go
 
-FROM golang:bookworm
+FROM golang:1.25-alpine
 ARG IMAGE_TAG
 ENV CGO_ENABLED=2
-RUN apt-get update && apt-get install -y git tree libchromaprint-tools
+RUN apk add --no-cache git tree chromaprint
 RUN mkdir -p /app/plugins
 WORKDIR /app
 ENV IMAGE_TAG=$IMAGE_TAG

--- a/src/infra/providers/acoustid.go
+++ b/src/infra/providers/acoustid.go
@@ -141,8 +141,17 @@ func (s *AcoustIDAPI) generateFingerprintWithFpcalc(ctx context.Context, filePat
 
 	// Run fpcalc to generate fingerprint
 	cmd := exec.CommandContext(ctx, "fpcalc", "-json", filePath)
-	output, err := cmd.Output()
+	output, err := cmd.CombinedOutput()
 	if err != nil {
+		// Try to parse output anyway in case fpcalc produced valid JSON despite errors
+		var result struct {
+			Fingerprint string  `json:"fingerprint"`
+			Duration    float64 `json:"duration"`
+		}
+		if parseErr := json.Unmarshal(output, &result); parseErr == nil && result.Fingerprint != "" {
+			// Successfully parsed fingerprint despite command error
+			return result.Fingerprint, int(result.Duration), nil
+		}
 		return "", 0, fmt.Errorf("failed to generate fingerprint with fpcalc: %w", err)
 	}
 


### PR DESCRIPTION
Chormaprint was failing for certain files for bookwork (debian). Exit status was 3 even though it managed to generate the fingerprint.  Resulting in some tracks not being imported or acoustid failing 
<img width="1251" height="313" alt="image" src="https://github.com/user-attachments/assets/4a451dfb-d575-4aa5-9a3f-d2bb8f0f93f6" />
The solution was to migrate to alpine that has a newer version of `fpcalc`, something that was in the backlog anyway. This probably was 

```
Debian:
# fpcalc -v
fpcalc version 1.5.1 (FFmpeg Lavc59.18.100 Lavf59.16.100 SwR4.3.100)
Alpine: 
/app # fpcalc -v
fpcalc version 1.6.0 (FFmpeg Lavc62.11.100 Lavf62.3.100 SwR6.1.100
```

References: 
https://www.reddit.com/r/MusicBrainz/comments/1ha5jx3/fpcalc_seems_to_be_broken_on_debian_bookworm/
https://blends.debian.org/multimedia/bugs/devel.html

