### PR TITLE
chore(refactor): library service

### DIFF
--- a/src/features/analyze/acoustid_job.go
+++ b/src/features/analyze/acoustid_job.go
@@ -28,7 +28,7 @@ func (t *AcoustIDJobTask) MetadataKeys() []string {
 // Execute performs the AcoustID analysis operation
 func (t *AcoustIDJobTask) Execute(ctx context.Context, job *jobs.Job, progressUpdater func(int, string)) (map[string]any, error) {
 	// Get total track count for progress reporting
-	totalTracks, err := t.service.libraryService.GetTracksCount(ctx)
+	totalTracks, err := t.service.library.GetTracksCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks count: %w", err)
 	}
@@ -63,7 +63,7 @@ func (t *AcoustIDJobTask) Execute(ctx context.Context, job *jobs.Job, progressUp
 		}
 
 		// Get next batch of tracks
-		tracks, err := t.service.libraryService.GetTracksPaginated(ctx, batchSize, offset)
+		tracks, err := t.service.library.GetTracksPaginated(ctx, batchSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get tracks batch (offset %d): %w", offset, err)
 		}
@@ -98,7 +98,7 @@ func (t *AcoustIDJobTask) Execute(ctx context.Context, job *jobs.Job, progressUp
 				// Continue with other tracks - don't fail the entire job
 			} else {
 				// Check if AcoustID was actually added
-				updatedTrack, err := t.service.libraryService.GetTrack(ctx, track.ID)
+				updatedTrack, err := t.service.library.GetTrack(ctx, track.ID)
 				if err != nil {
 					job.Logger.Warn("Failed to verify AcoustID addition for track", "trackID", track.ID, "title", track.Title, "error", err, "color", "orange")
 					fingerprintsAdded++ // Assume fingerprint was added

--- a/src/features/analyze/lyrics_job.go
+++ b/src/features/analyze/lyrics_job.go
@@ -47,7 +47,7 @@ func (t *LyricsJobTask) Execute(ctx context.Context, job *jobs.Job, progressUpda
 	job.Logger.Info("Enabled lyrics providers", "providers", enabledProviders, "color", "blue")
 
 	// Get total track count for progress reporting
-	totalTracks, err := t.service.libraryService.GetTracksCount(ctx)
+	totalTracks, err := t.service.library.GetTracksCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks count: %w", err)
 	}
@@ -80,7 +80,7 @@ func (t *LyricsJobTask) Execute(ctx context.Context, job *jobs.Job, progressUpda
 		}
 
 		// Get next batch of tracks
-		tracks, err := t.service.libraryService.GetTracksPaginated(ctx, batchSize, offset)
+		tracks, err := t.service.library.GetTracksPaginated(ctx, batchSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get tracks batch (offset %d): %w", offset, err)
 		}

--- a/src/features/analyze/service.go
+++ b/src/features/analyze/service.go
@@ -13,17 +13,17 @@ import (
 type Service struct {
 	taggingService music.MetadataService
 	lyricsService  music.LyricsService
-	libraryService music.LibraryService
+	library        music.Library
 	jobService     music.JobService
 	config         *config.Manager
 }
 
 // NewService creates a new analyze service
-func NewService(taggingService music.MetadataService, lyricsService music.LyricsService, libraryService music.LibraryService, jobService music.JobService, config *config.Manager) *Service {
+func NewService(taggingService music.MetadataService, lyricsService music.LyricsService, library music.Library, jobService music.JobService, config *config.Manager) *Service {
 	return &Service{
 		taggingService: taggingService,
 		lyricsService:  lyricsService,
-		libraryService: libraryService,
+		library:        library,
 		jobService:     jobService,
 		config:         config,
 	}

--- a/src/features/library/service.go
+++ b/src/features/library/service.go
@@ -11,9 +11,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// Ensure Service implements LibraryService interface
-var _ library.LibraryService = (*Service)(nil)
-
 // Service is the domain service for the library feature.
 type Service struct {
 	library       library.Library

--- a/src/main.go
+++ b/src/main.go
@@ -100,7 +100,7 @@ func main() {
 		"deezer":      deezerProvider,
 	}, acoustIDService, cfgManager)
 
-	analyzeService := analyze.NewService(tagService, lyricsService, libraryService, jobService, cfgManager) // Now using interfaces
+	analyzeService := analyze.NewService(tagService, lyricsService, db, jobService, cfgManager) // Now using interfaces
 	downloadingService := downloading.NewService(cfgManager, jobService, pluginManager, tagWriter)
 
 	downloadTask := downloading.NewDownloadJobTask(downloadingService)

--- a/src/music/services.go
+++ b/src/music/services.go
@@ -33,15 +33,6 @@ type LyricsService interface {
 	SearchLyrics(ctx context.Context, trackID string, providerName string) (string, error)
 }
 
-// LibraryService defines the interface for library operations
-type LibraryService interface { // TODO: Maybe use Repo instead of library service in the rest of the features
-	GetTracks(ctx context.Context) ([]*Track, error)
-	GetTracksPaginated(ctx context.Context, limit, offset int) ([]*Track, error)
-	GetTracksCount(ctx context.Context) (int, error)
-	GetTrack(ctx context.Context, trackID string) (*Track, error)
-	UpdateTrack(ctx context.Context, track *Track) error
-}
-
 // JobService defines the interface for job management
 type JobService interface {
 	StartJob(jobType string, name string, metadata map[string]any) (string, error)


### PR DESCRIPTION
Stop using library service as a domain service and start using library repostiory.

Someday I should maybe split that huge library repository.