### PR TITLE
fix(config): Database path display correctly

### DIFF
--- a/views/config/config_form.html
+++ b/views/config/config_form.html
@@ -10,7 +10,7 @@
           <div class="space-y-3">
              <div>
                 <label class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">Database Path</label>
-              <span class="bg-gray-100 dark:bg-gray-700 border border-gray-300/50 dark:border-gray-600/50 text-gray-900 dark:text-white text-sm rounded-lg block w-full px-3 py-1.5 backdrop-blur-sm">./library.db</span>
+               <span class="bg-gray-100 dark:bg-gray-700 border border-gray-300/50 dark:border-gray-600/50 text-gray-900 dark:text-white text-sm rounded-lg block w-full px-3 py-1.5 backdrop-blur-sm">{{.Config.Database.Path}}</span>
             </div>
              <a href="/config/database/download"
                 class="inline-flex items-center justify-center w-full px-5 py-2.5 backdrop-blur-sm hover:bg-blue-200/80 bg-blue-100/80 hover:dark:bg-blue-800/30 dark:bg-blue-900/30 border border-blue-200/50 dark:border-blue-700/50 text-sm text-blue-800 dark:text-blue-200 rounded-lg transition-colors font-medium">


### PR DESCRIPTION
Database path was hardcoded in the config form. Now it displays the `database: path:`  

```yaml
database:
  path: ./db/library.db
```

