### PR TITLE
feat(library): add [A-Z] to path template

### DIFF
--- a/src/infra/files/path_parser.go
+++ b/src/infra/files/path_parser.go
@@ -62,6 +62,17 @@ func (p *TemplatePathParser) renderPathTemplate(template string, track *music.Tr
 		switch funcName {
 		case "asciify":
 			return unidecode.Unidecode(argValue)
+		case "artistfolder":
+			asciified := unidecode.Unidecode(argValue)
+			if len(asciified) == 0 {
+				return "#/"
+			}
+			firstRune := rune(strings.ToUpper(string(asciified[0]))[0])
+			if firstRune >= 'A' && firstRune <= 'Z' {
+				return string(firstRune) + "/" + asciified
+			} else {
+				return "#/" + asciified
+			}
 		case "if":
 			// Simple if: %if{condition,true_value,false_value}
 			args := strings.Split(argValue, ",")


### PR DESCRIPTION
Solves #98 

Adding `#` and `[A-Z]` folders to the artists. Introduces `$artistfolder{}` function (I'm not 100% convinced with that name)

```text
./music_library
├── #
│   └── 1915
│       └── Bandera (2018)
│           └── 01 Policia.flac
└── R
    ├── ROSALIA
    │   └── LUX (2025)
    │       └── 07 La Perla.flac
    └── Rosemary Clooney
        └── White Christmas (2006)
            └── 11 Christmas Mem'ries.flac

9 directories, 3 files
```
In order to specify this, you should edit the template and wrap the `artists` or `albumartists` with under the function `%artistfolder{}` 
> [!WARNING]
> This also asciifies the artsts  


For example, wrapping the current default config: 
```text
  paths:
    compilations: '%artistfolder{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
    album:soundtrack: '%artistfolder{$albumartist}/%asciify{$album} [OST] (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
    album:single: '%artistfolder{$albumartist}/%asciify{$album} [Single] (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
    album:ep: '%artistfolder{$albumartist}/%asciify{$album} [EP] (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
    default_path: '%artistfolder{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
```