### PR TITLE
feat(analyze): Re-organize job for re-organizing library structure

### DIFF
--- a/src/features/analyze/handlers.go
+++ b/src/features/analyze/handlers.go
@@ -78,6 +78,32 @@ func (h *Handler) StartLyricsAnalysis(c *fiber.Ctx) error {
 	return c.Redirect("/ui/analyze")
 }
 
+// StartReorganizeAnalysis handles starting the file reorganization job
+func (h *Handler) StartReorganizeAnalysis(c *fiber.Ctx) error {
+	slog.Info("Starting file reorganization via HTTP request")
+
+	jobID, err := h.service.StartReorganizeAnalysis(c.Context())
+	if err != nil {
+		slog.Error("Failed to start file reorganization", "error", err)
+		return c.Render("toast/toastErr", fiber.Map{
+			"Msg": "Failed to start file reorganization: " + err.Error(),
+		})
+	}
+
+	slog.Info("File reorganization job started successfully", "jobID", jobID)
+
+	// Trigger HTMX to refresh the job list
+	c.Set("HX-Trigger", "refreshJobList")
+
+	if c.Get("HX-Request") == "true" {
+		return c.Render("toast/toastOk", fiber.Map{
+			"Msg": "File reorganization started successfully",
+		})
+	}
+
+	return c.Redirect("/ui/analyze")
+}
+
 // RenderAnalyzeSection renders the analyze section page
 func (h *Handler) RenderAnalyzeSection(c *fiber.Ctx) error {
 	slog.Debug("Rendering analyze section")

--- a/src/features/analyze/reorganize_job.go
+++ b/src/features/analyze/reorganize_job.go
@@ -1,0 +1,150 @@
+package analyze
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/contre95/soulsolid/src/features/jobs"
+)
+
+// ReorganizeJobTask handles file reorganization job execution
+type ReorganizeJobTask struct {
+	service *Service
+}
+
+// NewReorganizeJobTask creates a new reorganization job task
+func NewReorganizeJobTask(service *Service) *ReorganizeJobTask {
+	return &ReorganizeJobTask{
+		service: service,
+	}
+}
+
+// MetadataKeys returns the required metadata keys for reorganization jobs
+func (t *ReorganizeJobTask) MetadataKeys() []string {
+	return []string{}
+}
+
+// Execute performs the file reorganization operation
+func (t *ReorganizeJobTask) Execute(ctx context.Context, job *jobs.Job, progressUpdater func(int, string)) (map[string]any, error) {
+	// Get total track count for progress reporting
+	totalTracks, err := t.service.library.GetTracksCount(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get tracks count: %w", err)
+	}
+
+	if totalTracks == 0 {
+		job.Logger.Info("No tracks found in library")
+		return map[string]any{
+			"totalTracks": 0,
+			"processed":   0,
+			"moved":       0,
+			"skipped":     0,
+			"errors":      0,
+		}, nil
+	}
+
+	job.Logger.Info("Starting file reorganization", "totalTracks", totalTracks, "color", "blue")
+	progressUpdater(0, fmt.Sprintf("Starting reorganization of %d tracks", totalTracks))
+
+	processed := 0
+	moved := 0
+	skipped := 0
+	errors := 0
+
+	// Process tracks in batches to avoid loading all into memory
+	batchSize := 100
+	for offset := 0; offset < totalTracks; offset += batchSize {
+		select {
+		case <-ctx.Done():
+			job.Logger.Info("File reorganization cancelled", "processed", processed, "moved", moved, "color", "orange")
+			return nil, ctx.Err()
+		default:
+		}
+
+		// Get next batch of tracks
+		tracks, err := t.service.library.GetTracksPaginated(ctx, batchSize, offset)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get tracks batch (offset %d): %w", offset, err)
+		}
+
+		for _, track := range tracks {
+			select {
+			case <-ctx.Done():
+				job.Logger.Info("File reorganization cancelled", "processed", processed, "moved", moved, "color", "orange")
+				return nil, ctx.Err()
+			default:
+			}
+
+			progress := (processed * 100) / totalTracks
+			progressUpdater(progress, fmt.Sprintf("Processing track %d/%d: %s", processed+1, totalTracks, track.Title))
+
+			// Get the desired path for this track based on current config
+			desiredPath, err := t.service.fileManager.GetLibraryPath(ctx, track)
+			if err != nil {
+				job.Logger.Warn("Failed to get desired path for track", "trackID", track.ID, "title", track.Title, "error", err, "color", "orange")
+				errors++
+				continue
+			}
+
+			// Check if the track file exists on disk
+			if _, err := os.Stat(track.Path); os.IsNotExist(err) {
+				job.Logger.Info("Skipping track with missing file", "trackID", track.ID, "title", track.Title, "path", track.Path, "color", "orange")
+				skipped++
+				continue
+			}
+
+			// Normalize paths for comparison (handle relative vs absolute paths)
+			currentPath := filepath.Clean(track.Path)
+			desiredPath = filepath.Clean(desiredPath)
+
+			// Check if the track is already in the correct location
+			if currentPath == desiredPath {
+				job.Logger.Info("Track already in correct location", "trackID", track.ID, "title", track.Title, "path", currentPath, "color", "cyan")
+				skipped++
+				continue
+			}
+
+			// Move the track to the new location
+			job.Logger.Info("Moving track to new location", "trackID", track.ID, "title", track.Title, "from", currentPath, "to", desiredPath, "color", "yellow")
+			newPath, err := t.service.fileManager.MoveTrack(ctx, track)
+			if err != nil {
+				job.Logger.Warn("Failed to move track", "trackID", track.ID, "title", track.Title, "error", err, "color", "red")
+				errors++
+				continue
+			}
+
+			// Update the track path in the database
+			track.Path = newPath
+			err = t.service.library.UpdateTrack(ctx, track)
+			if err != nil {
+				job.Logger.Warn("Failed to update track path in database", "trackID", track.ID, "title", track.Title, "newPath", newPath, "error", err, "color", "red")
+				errors++
+				continue
+			}
+
+			job.Logger.Info("Successfully moved track", "trackID", track.ID, "title", track.Title, "newPath", newPath, "color", "green")
+			moved++
+			processed++
+		}
+	}
+
+	job.Logger.Info("File reorganization completed", "totalTracks", totalTracks, "processed", processed, "moved", moved, "skipped", skipped, "errors", errors, "color", "green")
+	progressUpdater(100, fmt.Sprintf("Reorganization completed - moved %d, skipped %d, errors %d", moved, skipped, errors))
+
+	return map[string]any{
+		"totalTracks": totalTracks,
+		"processed":   processed,
+		"moved":       moved,
+		"skipped":     skipped,
+		"errors":      errors,
+	}, nil
+}
+
+// Cleanup performs cleanup after job completion
+func (t *ReorganizeJobTask) Cleanup(job *jobs.Job) error {
+	slog.Debug("Cleaning up reorganization job", "jobID", job.ID)
+	return nil
+}

--- a/src/features/analyze/routes.go
+++ b/src/features/analyze/routes.go
@@ -10,6 +10,7 @@ func RegisterRoutes(app *fiber.App, handler *Handler) {
 	analyze := app.Group("/analyze")
 	analyze.Post("/acoustid", handler.StartAcoustIDAnalysis)
 	analyze.Post("/lyrics", handler.StartLyricsAnalysis)
+	analyze.Post("/reorganize", handler.StartReorganizeAnalysis)
 
 	// UI routes for the analyze section
 	ui := app.Group("/ui")

--- a/src/features/analyze/service.go
+++ b/src/features/analyze/service.go
@@ -16,16 +16,18 @@ type Service struct {
 	library        music.Library
 	jobService     music.JobService
 	config         *config.Manager
+	fileManager    music.FileManager
 }
 
 // NewService creates a new analyze service
-func NewService(taggingService music.MetadataService, lyricsService music.LyricsService, library music.Library, jobService music.JobService, config *config.Manager) *Service {
+func NewService(taggingService music.MetadataService, lyricsService music.LyricsService, library music.Library, jobService music.JobService, config *config.Manager, fileManager music.FileManager) *Service {
 	return &Service{
 		taggingService: taggingService,
 		lyricsService:  lyricsService,
 		library:        library,
 		jobService:     jobService,
 		config:         config,
+		fileManager:    fileManager,
 	}
 }
 
@@ -50,5 +52,16 @@ func (s *Service) StartLyricsAnalysis(ctx context.Context, provider string) (str
 		return "", fmt.Errorf("failed to start lyrics analysis job: %w", err)
 	}
 	slog.Info("Lyrics analysis job started", "jobID", jobID, "provider", provider)
+	return jobID, nil
+}
+
+// StartReorganizeAnalysis starts a job to reorganize all tracks based on current path configuration
+func (s *Service) StartReorganizeAnalysis(ctx context.Context) (string, error) {
+	slog.Info("Starting file reorganization job")
+	jobID, err := s.jobService.StartJob("analyze_reorganize", "Reorganize Library Files", map[string]any{})
+	if err != nil {
+		return "", fmt.Errorf("failed to start reorganization job: %w", err)
+	}
+	slog.Info("File reorganization job started", "jobID", jobID)
 	return jobID, nil
 }

--- a/src/main.go
+++ b/src/main.go
@@ -100,7 +100,7 @@ func main() {
 		"deezer":      deezerProvider,
 	}, acoustIDService, cfgManager)
 
-	analyzeService := analyze.NewService(tagService, lyricsService, db, jobService, cfgManager) // Now using interfaces
+	analyzeService := analyze.NewService(tagService, lyricsService, db, jobService, cfgManager, fileOrganizer) // Now using interfaces
 	downloadingService := downloading.NewService(cfgManager, jobService, pluginManager, tagWriter)
 
 	downloadTask := downloading.NewDownloadJobTask(downloadingService)
@@ -115,6 +115,9 @@ func main() {
 
 	lyricsTask := analyze.NewLyricsJobTask(analyzeService)
 	jobService.RegisterHandler("analyze_lyrics", jobs.NewBaseTaskHandler(lyricsTask))
+
+	reorganizeTask := analyze.NewReorganizeJobTask(analyzeService)
+	jobService.RegisterHandler("analyze_reorganize", jobs.NewBaseTaskHandler(reorganizeTask))
 
 	var telegramBot *hosting.TelegramBot
 	if cfgManager.Get().Telegram.Enabled {

--- a/views/sections/analyze.html
+++ b/views/sections/analyze.html
@@ -64,6 +64,30 @@
             </form>
         </div>
 
+        <!-- File Reorganization Card -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg">
+            <div class="flex items-center mb-4">
+                <svg class="w-8 h-8 text-blue-500 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"></path>
+                </svg>
+                <h3 class="text-xl font-semibold text-slate-800 dark:text-white">File Reorganization</h3>
+            </div>
+            <p class="text-slate-600 dark:text-slate-400 mb-4">
+                Reorganize all library files according to the current path configuration. Moves files that don't match the configured paths.
+            </p>
+            <button
+                hx-post="/analyze/reorganize"
+                hx-target="#toast-container"
+                hx-swap="beforeend"
+                class="w-full bg-green-500 hover:bg-green-600 text-white font-medium py-2 px-4 rounded-md transition-colors duration-200"
+            >
+                Start File Reorganization
+                <span class="htmx-indicator ml-2">
+                    <i class="fas fa-spinner fa-spin"></i>
+                </span>
+            </button>
+        </div>
+
         <div class="bg-white dark:bg-gray-800 rounded-lg p-6 shadow-lg opacity-50">
             <div class="flex items-center mb-4">
                 <svg class="w-8 h-8 text-gray-400 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
Introducing Re-Organize jobs within the Analyze feature to ensure your library files are consistently organized based on template paths.

<img width="2052" height="1540" alt="image" src="https://github.com/user-attachments/assets/5b6ecbe9-90b4-49a0-9103-423a9fb56ad3" />
