### PR TITLE
fix(library): Add tracks when searching albums and artists

### DIFF
--- a/src/features/library/handlers.go
+++ b/src/features/library/handlers.go
@@ -391,17 +391,33 @@ func (h *Handler) GetUnifiedSearch(c *fiber.Ctx) error {
 			}
 		}
 
-		// Search tracks
+		// Collect matched artist and album IDs to also fetch their tracks
+		var matchedArtistIDs []string
+		for _, r := range results {
+			if r.Type == "artist" {
+				matchedArtistIDs = append(matchedArtistIDs, r.ID)
+			}
+		}
+		var matchedAlbumIDs []string
+		for _, r := range results {
+			if r.Type == "album" {
+				matchedAlbumIDs = append(matchedAlbumIDs, r.ID)
+			}
+		}
+
+		// Search tracks by title
+		seenTrackIDs := make(map[string]bool)
 		filter := &music.TrackFilter{
 			Title:     query,
 			ArtistIDs: []string{},
 			AlbumIDs:  []string{},
 		}
-		tracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 20, 0, filter)
+		tracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 50, 0, filter)
 		if err != nil {
 			slog.Error("Error searching tracks", "error", err)
 		} else {
 			for _, track := range tracks {
+				seenTrackIDs[track.ID] = true
 				var artistNames strings.Builder
 				if len(track.Artists) > 0 {
 					for i, ar := range track.Artists {
@@ -424,6 +440,86 @@ func (h *Handler) GetUnifiedSearch(c *fiber.Ctx) error {
 					Duration:    track.Metadata.Duration,
 					ImageURL:    "",
 				})
+			}
+		}
+
+		// Fetch tracks belonging to matched artists
+		if len(matchedArtistIDs) > 0 {
+			artistTracksFilter := &music.TrackFilter{
+				ArtistIDs: matchedArtistIDs,
+			}
+			artistTracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 200, 0, artistTracksFilter)
+			if err != nil {
+				slog.Error("Error fetching tracks for matched artists", "error", err)
+			} else {
+				for _, track := range artistTracks {
+					if seenTrackIDs[track.ID] {
+						continue
+					}
+					seenTrackIDs[track.ID] = true
+					var artistNames strings.Builder
+					if len(track.Artists) > 0 {
+						for i, ar := range track.Artists {
+							if i > 0 {
+								artistNames.WriteString(", ")
+							}
+							artistNames.WriteString(ar.Artist.Name)
+						}
+					}
+					albumTitle := ""
+					if track.Album != nil {
+						albumTitle = track.Album.Title
+					}
+					results = append(results, SearchResult{
+						Type:        "track",
+						ID:          track.ID,
+						PrimaryName: track.Title,
+						Secondary:   artistNames.String(),
+						Tertiary:    albumTitle,
+						Duration:    track.Metadata.Duration,
+						ImageURL:    "",
+					})
+				}
+			}
+		}
+
+		// Fetch tracks belonging to matched albums
+		if len(matchedAlbumIDs) > 0 {
+			albumTracksFilter := &music.TrackFilter{
+				AlbumIDs: matchedAlbumIDs,
+			}
+			albumTracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 200, 0, albumTracksFilter)
+			if err != nil {
+				slog.Error("Error fetching tracks for matched albums", "error", err)
+			} else {
+				for _, track := range albumTracks {
+					if seenTrackIDs[track.ID] {
+						continue
+					}
+					seenTrackIDs[track.ID] = true
+					var artistNames strings.Builder
+					if len(track.Artists) > 0 {
+						for i, ar := range track.Artists {
+							if i > 0 {
+								artistNames.WriteString(", ")
+							}
+							artistNames.WriteString(ar.Artist.Name)
+						}
+					}
+					albumTitle := ""
+					if track.Album != nil {
+						albumTitle = track.Album.Title
+					}
+					results = append(results, SearchResult{
+						Type:        "track",
+						ID:          track.ID,
+						PrimaryName: track.Title,
+						Secondary:   artistNames.String(),
+						Tertiary:    albumTitle,
+						Duration:    track.Metadata.Duration,
+						ImageURL:    "",
+					})
+				}
 			}
 		}
 

--- a/src/features/library/handlers.go
+++ b/src/features/library/handlers.go
@@ -212,6 +212,29 @@ type SearchResult struct {
 	ImageURL    string // Image for display
 }
 
+// trackToSearchResult converts a music.Track to a SearchResult.
+func trackToSearchResult(track *music.Track) SearchResult {
+	var artistNames strings.Builder
+	for i, ar := range track.Artists {
+		if i > 0 {
+			artistNames.WriteString(", ")
+		}
+		artistNames.WriteString(ar.Artist.Name)
+	}
+	albumTitle := ""
+	if track.Album != nil {
+		albumTitle = track.Album.Title
+	}
+	return SearchResult{
+		Type:        "track",
+		ID:          track.ID,
+		PrimaryName: track.Title,
+		Secondary:   artistNames.String(),
+		Tertiary:    albumTitle,
+		Duration:    track.Metadata.Duration,
+	}
+}
+
 // GetUnifiedSearch performs a unified search across artists, albums, and tracks.
 func (h *Handler) GetUnifiedSearch(c *fiber.Ctx) error {
 	slog.Debug("GetUnifiedSearch handler called")
@@ -355,26 +378,22 @@ func (h *Handler) GetUnifiedSearch(c *fiber.Ctx) error {
 					ID:          artist.ID,
 					PrimaryName: artist.Name,
 					Secondary:   artist.ID,
-					Tertiary:    "",
-					ImageURL:    "",
 				})
 			}
 		}
 
-		// Search albums
-		albums, err := h.service.GetAlbumsFilteredPaginated(c.Context(), 20, 0, query, []string{})
+		// Search albums (lightweight: single JOIN query, no N+1)
+		albums, err := h.service.SearchAlbums(c.Context(), query, 20, 0)
 		if err != nil {
 			slog.Error("Error searching albums", "error", err)
 		} else {
 			for _, album := range albums {
 				var artistNames strings.Builder
-				if len(album.Artists) > 0 {
-					for i, ar := range album.Artists {
-						if i > 0 {
-							artistNames.WriteString(", ")
-						}
-						artistNames.WriteString(ar.Artist.Name)
+				for i, ar := range album.Artists {
+					if i > 0 {
+						artistNames.WriteString(", ")
 					}
+					artistNames.WriteString(ar.Artist.Name)
 				}
 				year := ""
 				if !album.ReleaseDate.IsZero() {
@@ -386,140 +405,17 @@ func (h *Handler) GetUnifiedSearch(c *fiber.Ctx) error {
 					PrimaryName: album.Title,
 					Secondary:   artistNames.String(),
 					Tertiary:    year,
-					ImageURL:    album.ImageSmall,
 				})
 			}
 		}
 
-		// Collect matched artist and album IDs to also fetch their tracks
-		var matchedArtistIDs []string
-		for _, r := range results {
-			if r.Type == "artist" {
-				matchedArtistIDs = append(matchedArtistIDs, r.ID)
-			}
-		}
-		var matchedAlbumIDs []string
-		for _, r := range results {
-			if r.Type == "album" {
-				matchedAlbumIDs = append(matchedAlbumIDs, r.ID)
-			}
-		}
-
-		// Search tracks by title
-		seenTrackIDs := make(map[string]bool)
-		filter := &music.TrackFilter{
-			Title:     query,
-			ArtistIDs: []string{},
-			AlbumIDs:  []string{},
-		}
-		tracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 50, 0, filter)
+		// Search tracks: single query OR-matching title, artist name, and album title
+		tracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 500, 0, &music.TrackFilter{TextSearch: query})
 		if err != nil {
 			slog.Error("Error searching tracks", "error", err)
 		} else {
 			for _, track := range tracks {
-				seenTrackIDs[track.ID] = true
-				var artistNames strings.Builder
-				if len(track.Artists) > 0 {
-					for i, ar := range track.Artists {
-						if i > 0 {
-							artistNames.WriteString(", ")
-						}
-						artistNames.WriteString(ar.Artist.Name)
-					}
-				}
-				albumTitle := ""
-				if track.Album != nil {
-					albumTitle = track.Album.Title
-				}
-				results = append(results, SearchResult{
-					Type:        "track",
-					ID:          track.ID,
-					PrimaryName: track.Title,
-					Secondary:   artistNames.String(),
-					Tertiary:    albumTitle,
-					Duration:    track.Metadata.Duration,
-					ImageURL:    "",
-				})
-			}
-		}
-
-		// Fetch tracks belonging to matched artists
-		if len(matchedArtistIDs) > 0 {
-			artistTracksFilter := &music.TrackFilter{
-				ArtistIDs: matchedArtistIDs,
-			}
-			artistTracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 200, 0, artistTracksFilter)
-			if err != nil {
-				slog.Error("Error fetching tracks for matched artists", "error", err)
-			} else {
-				for _, track := range artistTracks {
-					if seenTrackIDs[track.ID] {
-						continue
-					}
-					seenTrackIDs[track.ID] = true
-					var artistNames strings.Builder
-					if len(track.Artists) > 0 {
-						for i, ar := range track.Artists {
-							if i > 0 {
-								artistNames.WriteString(", ")
-							}
-							artistNames.WriteString(ar.Artist.Name)
-						}
-					}
-					albumTitle := ""
-					if track.Album != nil {
-						albumTitle = track.Album.Title
-					}
-					results = append(results, SearchResult{
-						Type:        "track",
-						ID:          track.ID,
-						PrimaryName: track.Title,
-						Secondary:   artistNames.String(),
-						Tertiary:    albumTitle,
-						Duration:    track.Metadata.Duration,
-						ImageURL:    "",
-					})
-				}
-			}
-		}
-
-		// Fetch tracks belonging to matched albums
-		if len(matchedAlbumIDs) > 0 {
-			albumTracksFilter := &music.TrackFilter{
-				AlbumIDs: matchedAlbumIDs,
-			}
-			albumTracks, err := h.service.GetTracksFilteredPaginated(c.Context(), 200, 0, albumTracksFilter)
-			if err != nil {
-				slog.Error("Error fetching tracks for matched albums", "error", err)
-			} else {
-				for _, track := range albumTracks {
-					if seenTrackIDs[track.ID] {
-						continue
-					}
-					seenTrackIDs[track.ID] = true
-					var artistNames strings.Builder
-					if len(track.Artists) > 0 {
-						for i, ar := range track.Artists {
-							if i > 0 {
-								artistNames.WriteString(", ")
-							}
-							artistNames.WriteString(ar.Artist.Name)
-						}
-					}
-					albumTitle := ""
-					if track.Album != nil {
-						albumTitle = track.Album.Title
-					}
-					results = append(results, SearchResult{
-						Type:        "track",
-						ID:          track.ID,
-						PrimaryName: track.Title,
-						Secondary:   artistNames.String(),
-						Tertiary:    albumTitle,
-						Duration:    track.Metadata.Duration,
-						ImageURL:    "",
-					})
-				}
+				results = append(results, trackToSearchResult(track))
 			}
 		}
 

--- a/src/features/library/service.go
+++ b/src/features/library/service.go
@@ -251,6 +251,18 @@ func (s *Service) GetAlbumsFilteredCount(ctx context.Context, titleFilter string
 	return count, nil
 }
 
+// SearchAlbums returns albums matching query using a single lightweight JOIN query.
+func (s *Service) SearchAlbums(ctx context.Context, query string, limit, offset int) ([]*library.Album, error) {
+	slog.Debug("SearchAlbums service called", "query", query, "limit", limit, "offset", offset)
+	albums, err := s.library.SearchAlbums(ctx, query, limit, offset)
+	if err != nil {
+		slog.Error("SearchAlbums failed", "error", err)
+		return nil, err
+	}
+	slog.Debug("SearchAlbums completed", "count", len(albums))
+	return albums, nil
+}
+
 // GetAlbumsCount returns the total count of albums in the library.
 func (s *Service) GetAlbumsCount(ctx context.Context) (int, error) {
 	slog.Debug("GetAlbumsCount service called")

--- a/src/infra/database/sqlite.go
+++ b/src/infra/database/sqlite.go
@@ -1369,6 +1369,13 @@ func (d *SqliteLibrary) GetTracksFilteredPaginated(ctx context.Context, limit, o
 		args = append(args, "%"+filter.Title+"%")
 	}
 
+	// Add text search: OR-match across track title, artist name, album title
+	if filter.TextSearch != "" {
+		like := "%" + filter.TextSearch + "%"
+		conditions = append(conditions, `(t.title LIKE ? OR EXISTS (SELECT 1 FROM track_artists ta2 JOIN artists a2 ON ta2.artist_id = a2.id WHERE ta2.track_id = t.id AND a2.name LIKE ?) OR EXISTS (SELECT 1 FROM track_albums tal2 JOIN albums al2 ON tal2.album_id = al2.id WHERE tal2.track_id = t.id AND al2.title LIKE ?))`)
+		args = append(args, like, like, like)
+	}
+
 	// Add artist filter
 	if len(filter.ArtistIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(filter.ArtistIDs))
@@ -1438,6 +1445,13 @@ func (d *SqliteLibrary) GetTracksFilteredCount(ctx context.Context, filter *musi
 		args = append(args, "%"+filter.Title+"%")
 	}
 
+	// Add text search: OR-match across track title, artist name, album title
+	if filter.TextSearch != "" {
+		like := "%" + filter.TextSearch + "%"
+		conditions = append(conditions, `(t.title LIKE ? OR EXISTS (SELECT 1 FROM track_artists ta2 JOIN artists a2 ON ta2.artist_id = a2.id WHERE ta2.track_id = t.id AND a2.name LIKE ?) OR EXISTS (SELECT 1 FROM track_albums tal2 JOIN albums al2 ON tal2.album_id = al2.id WHERE tal2.track_id = t.id AND al2.title LIKE ?))`)
+		args = append(args, like, like, like)
+	}
+
 	// Add artist filter
 	if len(filter.ArtistIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(filter.ArtistIDs))
@@ -1468,6 +1482,45 @@ func (d *SqliteLibrary) GetTracksFilteredCount(ctx context.Context, filter *musi
 		return 0, err
 	}
 	return count, nil
+}
+
+// SearchAlbums returns albums matching the query with a single JOIN query (no N+1).
+// Only fields needed for search display are populated: ID, Title, ReleaseDate, Artists[].Artist.Name.
+func (d *SqliteLibrary) SearchAlbums(ctx context.Context, query string, limit, offset int) ([]*music.Album, error) {
+	rows, err := d.db.QueryContext(ctx, `
+		SELECT a.id, a.title, a.release_date,
+		       GROUP_CONCAT(ar.name, '|||') as artist_names
+		FROM albums a
+		LEFT JOIN album_artists aa ON a.id = aa.album_id
+		LEFT JOIN artists ar ON aa.artist_id = ar.id
+		WHERE a.title LIKE ?
+		GROUP BY a.id
+		ORDER BY a.title
+		LIMIT ? OFFSET ?
+	`, "%"+query+"%", limit, offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var albums []*music.Album
+	for rows.Next() {
+		album := &music.Album{}
+		var releaseDateStr string
+		var artistNamesNull sql.NullString
+		if err := rows.Scan(&album.ID, &album.Title, &releaseDateStr, &artistNamesNull); err != nil {
+			return nil, err
+		}
+		album.ReleaseDate, _ = time.Parse(time.RFC3339, releaseDateStr)
+		if artistNamesNull.Valid && artistNamesNull.String != "" {
+			for _, name := range strings.Split(artistNamesNull.String, "|||") {
+				n := name // copy for pointer
+				album.Artists = append(album.Artists, music.ArtistRole{Artist: &music.Artist{Name: n}})
+			}
+		}
+		albums = append(albums, album)
+	}
+	return albums, rows.Err()
 }
 
 // GetTracksCount gets the total count of tracks in the database.

--- a/src/music/library.go
+++ b/src/music/library.go
@@ -6,9 +6,10 @@ import (
 
 // TrackFilter represents the filter criteria for tracks.
 type TrackFilter struct {
-	Title     string
-	ArtistIDs []string
-	AlbumIDs  []string
+	Title      string
+	ArtistIDs  []string
+	AlbumIDs   []string
+	TextSearch string // OR-match across track title, artist name, and album title
 }
 
 // Library is the interface for managing the music library.
@@ -37,6 +38,7 @@ type Library interface {
 	GetAlbumsFilteredPaginated(ctx context.Context, limit, offset int, titleFilter string, artistIDs []string) ([]*Album, error)
 	GetAlbumsCount(ctx context.Context) (int, error)
 	GetAlbumsFilteredCount(ctx context.Context, titleFilter string, artistIDs []string) (int, error)
+	SearchAlbums(ctx context.Context, query string, limit, offset int) ([]*Album, error)
 	GetAlbumByArtistAndName(ctx context.Context, artistID, name string) (*Album, error)
 	FindOrCreateAlbum(ctx context.Context, artist *Artist, albumTitle string, year int) (*Album, error)
 


### PR DESCRIPTION
## Biggest change 
  Before: 3 queries + Go glue

  Query 1: tracks WHERE title LIKE "Beatles"
    → [track A, track B]

  Query 2: tracks WHERE artist_id IN (matched_artist_ids)
    → [track A, track C, track D]   ← A is a duplicate!

  Query 3: tracks WHERE album_id IN (matched_album_ids)
    → [track C, track E]             ← C is a duplicate!

  Go code: merge + deduplicate with seenTrackIDs map
    → [track A, track B, track C, track D, track E]

  Three round-trips to the database, Go has to stitch the results together, and the hardcoded limits (50, 200, 200) are arbitrary guesses — too low
  and you miss results, too high and you waste memory.

  ---
  After: 1 query

  The key insight is that SQL's WHERE ... OR ... already does the union and deduplication natively with SELECT DISTINCT:
```sql
  SELECT DISTINCT t.id FROM tracks t
  WHERE
    t.title LIKE '%Beatles%'
    OR EXISTS (
      SELECT 1 FROM track_artists ta
      JOIN artists a ON ta.artist_id = a.id
      WHERE ta.track_id = t.id AND a.name LIKE '%Beatles%'
    )
    OR EXISTS (
      SELECT 1 FROM track_albums tal
      JOIN albums al ON tal.album_id = al.id
      WHERE tal.track_id = t.id AND al.title LIKE '%Beatles%'
    )
```
  `EXISTS (SELECT 1 ...)` is a correlated subquery — for each track row t, it asks "does a related row exist that matches?" It short-circuits on the
  first match, so it's efficient.

  DISTINCT handles deduplication — if a track matches on both title AND artist name, it still appears once.

  The result is one query that returns exactly the right set of track IDs, with no arbitrary limits and no Go-side merging needed.

  ---
  Why EXISTS instead of JOIN?

  You might wonder why not just:
```sql
  SELECT DISTINCT t.id FROM tracks t
  LEFT JOIN track_artists ta ON ta.track_id = t.id
  LEFT JOIN artists a ON ta.artist_id = a.id
  LEFT JOIN track_albums tal ON tal.track_id = t.id
  LEFT JOIN albums al ON tal.album_id = al.id
  WHERE t.title LIKE ? OR a.name LIKE ? OR al.title LIKE ?
```
  That works but JOIN multiplies rows — a track with 3 artists and 1 album produces 3 rows before DISTINCT collapses them. EXISTS avoids that
  inflation entirely; it just checks for presence without pulling data.
