### PR TITLE
FAT32 support for reorganize path jobs

### DIFF
--- a/src/features/importing/directory_job.go
+++ b/src/features/importing/directory_job.go
@@ -169,9 +169,9 @@ func (e *DirectoryImportTask) importFile(ctx context.Context, track *music.Track
 	var newPath string
 	var err error
 	if moveFiles {
-		newPath, err = e.service.fileManager.MoveTrack(ctx, track)
+		newPath, err = e.service.fileManager.MoveTrackToLibrary(ctx, track)
 	} else {
-		newPath, err = e.service.fileManager.CopyTrack(ctx, track)
+		newPath, err = e.service.fileManager.CopyTrackToLibrary(ctx, track)
 	}
 	if err != nil {
 		logger.Error("Service.runDirectoryImport: could not organize track", "error", err)

--- a/src/features/importing/service.go
+++ b/src/features/importing/service.go
@@ -285,9 +285,9 @@ func (s *Service) replaceTrack(ctx context.Context, newTrack, existingTrack *mus
 	var newPath string
 	var err error
 	if move {
-		newPath, err = s.fileManager.MoveTrack(ctx, newTrack)
+		newPath, err = s.fileManager.MoveTrackToLibrary(ctx, newTrack)
 	} else {
-		newPath, err = s.fileManager.CopyTrack(ctx, newTrack)
+		newPath, err = s.fileManager.CopyTrackToLibrary(ctx, newTrack)
 	}
 	if err != nil {
 		return fmt.Errorf("could not organize replacement track: %w", err)
@@ -379,9 +379,9 @@ func (s *Service) importTrack(ctx context.Context, track *music.Track, move bool
 	var err error
 
 	if move {
-		newPath, err = s.fileManager.MoveTrack(ctx, track)
+		newPath, err = s.fileManager.MoveTrackToLibrary(ctx, track)
 	} else {
-		newPath, err = s.fileManager.CopyTrack(ctx, track)
+		newPath, err = s.fileManager.CopyTrackToLibrary(ctx, track)
 	}
 	if err != nil {
 		logger.Error("Service.importTrack: could not organize track", "error", err, "title", track.Title)

--- a/src/features/reorganize/handlers.go
+++ b/src/features/reorganize/handlers.go
@@ -25,7 +25,8 @@ func NewHandler(service *Service, config *config.Manager) *Handler {
 func (h *Handler) StartReorganizeAnalysis(c *fiber.Ctx) error {
 	slog.Info("Starting file reorganization job from web request")
 
-	jobID, err := h.service.StartReorganizeAnalysis(c.Context())
+	fat32Safe := c.FormValue("fat32_safe") == "true"
+	jobID, err := h.service.StartReorganizeAnalysis(c.Context(), fat32Safe)
 	if err != nil {
 		slog.Error("Failed to start file reorganization job", "error", err)
 		return c.Status(fiber.StatusInternalServerError).Render("toast/toastError", fiber.Map{

--- a/src/features/reorganize/handlers.go
+++ b/src/features/reorganize/handlers.go
@@ -35,6 +35,8 @@ func (h *Handler) StartReorganizeAnalysis(c *fiber.Ctx) error {
 
 	slog.Info("File reorganization job started", "jobID", jobID)
 
+	c.Set("HX-Trigger", "refreshJobList")
+
 	if c.Get("HX-Request") == "true" {
 		return c.Render("toast/toastOk", fiber.Map{
 			"Msg": "File reorganization started successfully",

--- a/src/features/reorganize/job.go
+++ b/src/features/reorganize/job.go
@@ -49,7 +49,7 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 	job.Logger.Info("Starting file reorganization", "totalTracks", totalTracks, "color", "blue")
 	progressUpdater(0, fmt.Sprintf("Starting reorganization of %d tracks", totalTracks))
 
-	processed := 0
+	attempted := 0
 	moved := 0
 	skipped := 0
 	errors := 0
@@ -59,7 +59,7 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 	for offset := 0; offset < totalTracks; offset += batchSize {
 		select {
 		case <-ctx.Done():
-			job.Logger.Info("File reorganization cancelled", "processed", processed, "moved", moved, "color", "orange")
+			job.Logger.Info("File reorganization cancelled", "attempted", attempted, "moved", moved, "color", "orange")
 			return nil, ctx.Err()
 		default:
 		}
@@ -73,13 +73,14 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 		for _, track := range tracks {
 			select {
 			case <-ctx.Done():
-				job.Logger.Info("File reorganization cancelled", "processed", processed, "moved", moved, "color", "orange")
+				job.Logger.Info("File reorganization cancelled", "attempted", attempted, "moved", moved, "color", "orange")
 				return nil, ctx.Err()
 			default:
 			}
 
-			progress := (processed * 100) / totalTracks
-			progressUpdater(progress, fmt.Sprintf("Processing track %d/%d: %s", processed+1, totalTracks, track.Title))
+			progress := (attempted * 100) / totalTracks
+			progressUpdater(progress, fmt.Sprintf("Processing track %d/%d: %s", attempted+1, totalTracks, track.Title))
+			attempted++
 
 			// Get the desired path for this track based on current config
 			desiredPath, err := t.service.fileManager.GetLibraryPath(ctx, track)
@@ -127,19 +128,19 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 
 			job.Logger.Info("Successfully moved track", "trackID", track.ID, "title", track.Title, "newPath", newPath, "color", "green")
 			moved++
-			processed++
 		}
 	}
 
-	job.Logger.Info("File reorganization completed", "totalTracks", totalTracks, "processed", processed, "moved", moved, "skipped", skipped, "errors", errors, "color", "green")
-	progressUpdater(100, fmt.Sprintf("Reorganization completed - moved %d, skipped %d, errors %d", moved, skipped, errors))
+	finalMsg := fmt.Sprintf("Reorganization completed: %d path(s) modified, %d already correct, %d errors (of %d total tracks)", moved, skipped, errors, totalTracks)
+	job.Logger.Info("File reorganization completed", "totalTracks", totalTracks, "moved", moved, "skipped", skipped, "errors", errors, "color", "green")
+	progressUpdater(100, fmt.Sprintf("Done — %d path(s) modified, %d skipped, %d errors", moved, skipped, errors))
 
 	return map[string]any{
 		"totalTracks": totalTracks,
-		"processed":   processed,
 		"moved":       moved,
 		"skipped":     skipped,
 		"errors":      errors,
+		"msg":         finalMsg,
 	}, nil
 }
 

--- a/src/features/reorganize/job.go
+++ b/src/features/reorganize/job.go
@@ -122,7 +122,7 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 
 			// Move the track to the new location
 			job.Logger.Info("Moving track to new location", "trackID", track.ID, "title", track.Title, "from", currentPath, "to", desiredPath, "color", "yellow")
-			newPath, err := t.service.fileManager.MoveTrackToPath(ctx, track, desiredPath)
+			newPath, err := t.service.fileManager.MoveTrackFile(ctx, track.Path, desiredPath)
 			if err != nil {
 				job.Logger.Warn("Failed to move track", "trackID", track.ID, "title", track.Title, "error", err, "color", "red")
 				errors++

--- a/src/features/reorganize/job.go
+++ b/src/features/reorganize/job.go
@@ -10,24 +10,20 @@ import (
 	"github.com/contre95/soulsolid/src/music"
 )
 
-// ReorganizeJobTask handles file reorganization job execution
 type ReorganizeJobTask struct {
 	service *Service
 }
 
-// NewReorganizeJobTask creates a new reorganization job task
 func NewReorganizeJobTask(service *Service) *ReorganizeJobTask {
 	return &ReorganizeJobTask{
 		service: service,
 	}
 }
 
-// MetadataKeys returns the required metadata keys for reorganization jobs
 func (t *ReorganizeJobTask) MetadataKeys() []string {
 	return []string{}
 }
 
-// Execute performs the file reorganization operation
 func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progressUpdater func(int, string)) (map[string]any, error) {
 	fat32Safe := false
 	if v, ok := job.Metadata["fat32_safe"]; ok {
@@ -36,7 +32,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 		}
 	}
 
-	// Get total track count for progress reporting
 	totalTracks, err := t.service.library.GetTracksCount(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get tracks count: %w", err)
@@ -61,7 +56,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 	skipped := 0
 	errors := 0
 
-	// Process tracks in batches to avoid loading all into memory
 	batchSize := 100
 	for offset := 0; offset < totalTracks; offset += batchSize {
 		select {
@@ -71,7 +65,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 		default:
 		}
 
-		// Get next batch of tracks
 		tracks, err := t.service.library.GetTracksPaginated(ctx, batchSize, offset)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get tracks batch (offset %d): %w", offset, err)
@@ -89,7 +82,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 			progressUpdater(progress, fmt.Sprintf("Processing track %d/%d: %s", attempted+1, totalTracks, track.Title))
 			attempted++
 
-			// Get the desired path for this track based on current config
 			desiredPath, err := t.service.fileManager.GetLibraryPath(ctx, track)
 			if err != nil {
 				job.Logger.Warn("Failed to get desired path for track", "trackID", track.ID, "title", track.Title, "error", err, "color", "orange")
@@ -97,30 +89,25 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 				continue
 			}
 
-			// Check if the track file exists on disk
 			if _, err := os.Stat(track.Path); os.IsNotExist(err) {
 				job.Logger.Info("Skipping track with missing file", "trackID", track.ID, "title", track.Title, "path", track.Path, "color", "orange")
 				skipped++
 				continue
 			}
 
-			// Normalize paths for comparison (handle relative vs absolute paths)
 			currentPath := filepath.Clean(track.Path)
 			desiredPath = filepath.Clean(desiredPath)
 
-			// Apply FAT32 sanitization to the desired path if requested
 			if fat32Safe {
 				desiredPath = sanitizeFAT32Path(desiredPath)
 			}
 
-			// Check if the track is already in the correct location
 			if currentPath == desiredPath {
 				job.Logger.Info("Track already in correct location", "trackID", track.ID, "title", track.Title, "path", currentPath, "color", "cyan")
 				skipped++
 				continue
 			}
 
-			// Move the track to the new location
 			job.Logger.Info("Moving track to new location", "trackID", track.ID, "title", track.Title, "from", currentPath, "to", desiredPath, "color", "yellow")
 			newPath, err := t.service.fileManager.MoveTrackFile(ctx, track.Path, desiredPath)
 			if err != nil {
@@ -129,7 +116,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 				continue
 			}
 
-			// Update the track path in the database
 			track.Path = newPath
 			err = t.service.library.UpdateTrack(ctx, track)
 			if err != nil {
@@ -156,7 +142,6 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 	}, nil
 }
 
-// Cleanup performs cleanup after job completion
 func (t *ReorganizeJobTask) Cleanup(job *music.Job) error {
 	slog.Debug("Cleaning up reorganization job", "jobID", job.ID)
 	return nil

--- a/src/features/reorganize/job.go
+++ b/src/features/reorganize/job.go
@@ -29,6 +29,13 @@ func (t *ReorganizeJobTask) MetadataKeys() []string {
 
 // Execute performs the file reorganization operation
 func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progressUpdater func(int, string)) (map[string]any, error) {
+	fat32Safe := false
+	if v, ok := job.Metadata["fat32_safe"]; ok {
+		if b, ok := v.(bool); ok {
+			fat32Safe = b
+		}
+	}
+
 	// Get total track count for progress reporting
 	totalTracks, err := t.service.library.GetTracksCount(ctx)
 	if err != nil {
@@ -39,14 +46,14 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 		job.Logger.Info("No tracks found in library")
 		return map[string]any{
 			"totalTracks": 0,
-			"processed":   0,
 			"moved":       0,
 			"skipped":     0,
 			"errors":      0,
+			"msg":         "No tracks found in library",
 		}, nil
 	}
 
-	job.Logger.Info("Starting file reorganization", "totalTracks", totalTracks, "color", "blue")
+	job.Logger.Info("Starting file reorganization", "totalTracks", totalTracks, "fat32Safe", fat32Safe, "color", "blue")
 	progressUpdater(0, fmt.Sprintf("Starting reorganization of %d tracks", totalTracks))
 
 	attempted := 0
@@ -101,6 +108,11 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 			currentPath := filepath.Clean(track.Path)
 			desiredPath = filepath.Clean(desiredPath)
 
+			// Apply FAT32 sanitization to the desired path if requested
+			if fat32Safe {
+				desiredPath = sanitizeFAT32Path(desiredPath)
+			}
+
 			// Check if the track is already in the correct location
 			if currentPath == desiredPath {
 				job.Logger.Info("Track already in correct location", "trackID", track.ID, "title", track.Title, "path", currentPath, "color", "cyan")
@@ -110,7 +122,7 @@ func (t *ReorganizeJobTask) Execute(ctx context.Context, job *music.Job, progres
 
 			// Move the track to the new location
 			job.Logger.Info("Moving track to new location", "trackID", track.ID, "title", track.Title, "from", currentPath, "to", desiredPath, "color", "yellow")
-			newPath, err := t.service.fileManager.MoveTrack(ctx, track)
+			newPath, err := t.service.fileManager.MoveTrackToPath(ctx, track, desiredPath)
 			if err != nil {
 				job.Logger.Warn("Failed to move track", "trackID", track.ID, "title", track.Title, "error", err, "color", "red")
 				errors++

--- a/src/features/reorganize/sanitize.go
+++ b/src/features/reorganize/sanitize.go
@@ -6,20 +6,13 @@ import (
 	"unicode/utf8"
 )
 
-// maxFAT32Bytes is the maximum byte length of a single FAT32 filename component.
 const maxFAT32Bytes = 255
 
-// fat32Replacer replaces every FAT32-forbidden character with a hyphen.
-// Compiled once at package init; applied in O(n) per segment.
 var fat32Replacer = strings.NewReplacer(
 	":", "-", "*", "-", "?", "-", `"`, "-",
 	"<", "-", ">", "-", "|", "-", `\`, "-",
 )
 
-// sanitizeFAT32Path makes every segment of a file path UTF-8 valid and free of
-// FAT32-forbidden characters (: * ? " < > | \). Path separators are preserved;
-// only individual segments are processed. The final segment (the filename) has
-// its extension preserved when truncating to the 255-byte FAT32 limit.
 func sanitizeFAT32Path(path string) string {
 	segments := strings.Split(path, string(filepath.Separator))
 	last := len(segments) - 1
@@ -29,27 +22,13 @@ func sanitizeFAT32Path(path string) string {
 	return strings.Join(segments, string(filepath.Separator))
 }
 
-// sanitizeFAT32Segment cleans a single path component.
-// isFilename should be true for the final segment so the file extension is
-// preserved when the name needs to be truncated.
 func sanitizeFAT32Segment(seg string, isFilename bool) string {
 	if seg == "" {
 		return seg
 	}
-
-	// Strip invalid UTF-8 sequences.
 	seg = strings.ToValidUTF8(seg, "")
-
-	// Replace FAT32-forbidden characters with hyphens.
 	result := fat32Replacer.Replace(seg)
-
-	// FAT32 names must not end with a dot or a space (applies to both files
-	// and directories).
 	result = strings.TrimRight(result, ". ")
-
-	// Enforce the 255-byte FAT32 filename limit.
-	// For the filename segment, preserve the extension so the file remains
-	// openable even after truncation.
 	if isFilename {
 		ext := filepath.Ext(result)
 		stem := result[:len(result)-len(ext)]
@@ -61,20 +40,15 @@ func sanitizeFAT32Segment(seg string, isFilename bool) string {
 	} else {
 		result = truncateBytesUTF8(result, maxFAT32Bytes)
 	}
-
 	return result
 }
 
-// truncateBytesUTF8 shortens s to at most maxBytes bytes, cutting only at valid
-// UTF-8 rune boundaries so the result is always a well-formed string.
+// truncateBytesUTF8 cuts s to maxBytes, stepping back to a valid UTF-8 rune boundary.
 func truncateBytesUTF8(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
 	}
 	truncated := s[:maxBytes]
-	// Step back past any incomplete multi-byte rune at the cut point.
-	// DecodeLastRuneInString returns RuneError with width 1 for invalid bytes;
-	// at most 3 iterations are needed (max UTF-8 sequence is 4 bytes).
 	for len(truncated) > 0 {
 		r, size := utf8.DecodeLastRuneInString(truncated)
 		if r != utf8.RuneError || size != 1 {

--- a/src/features/reorganize/sanitize.go
+++ b/src/features/reorganize/sanitize.go
@@ -6,11 +6,15 @@ import (
 	"unicode/utf8"
 )
 
-// fat32Forbidden contains all characters disallowed in FAT32 filenames.
-const fat32Forbidden = `:*?"<>|\`
-
 // maxFAT32Bytes is the maximum byte length of a single FAT32 filename component.
 const maxFAT32Bytes = 255
+
+// fat32Replacer replaces every FAT32-forbidden character with a hyphen.
+// Compiled once at package init; applied in O(n) per segment.
+var fat32Replacer = strings.NewReplacer(
+	":", "-", "*", "-", "?", "-", `"`, "-",
+	"<", "-", ">", "-", "|", "-", `\`, "-",
+)
 
 // sanitizeFAT32Path makes every segment of a file path UTF-8 valid and free of
 // FAT32-forbidden characters (: * ? " < > | \). Path separators are preserved;
@@ -36,21 +40,11 @@ func sanitizeFAT32Segment(seg string, isFilename bool) string {
 	// Strip invalid UTF-8 sequences.
 	seg = strings.ToValidUTF8(seg, "")
 
-	// Replace each FAT32-forbidden character with a hyphen.
-	var b strings.Builder
-	b.Grow(len(seg))
-	for _, r := range seg {
-		if strings.ContainsRune(fat32Forbidden, r) {
-			b.WriteRune('-')
-		} else {
-			b.WriteRune(r)
-		}
-	}
-	result := b.String()
+	// Replace FAT32-forbidden characters with hyphens.
+	result := fat32Replacer.Replace(seg)
 
 	// FAT32 names must not end with a dot or a space (applies to both files
-	// and directories; for files the extension already prevents a trailing dot
-	// under normal circumstances, but we trim here to be safe).
+	// and directories).
 	result = strings.TrimRight(result, ". ")
 
 	// Enforce the 255-byte FAT32 filename limit.
@@ -78,8 +72,14 @@ func truncateBytesUTF8(s string, maxBytes int) string {
 		return s
 	}
 	truncated := s[:maxBytes]
-	// Walk back until the slice ends on a valid rune boundary.
-	for !utf8.ValidString(truncated) {
+	// Step back past any incomplete multi-byte rune at the cut point.
+	// DecodeLastRuneInString returns RuneError with width 1 for invalid bytes;
+	// at most 3 iterations are needed (max UTF-8 sequence is 4 bytes).
+	for len(truncated) > 0 {
+		r, size := utf8.DecodeLastRuneInString(truncated)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated

--- a/src/features/reorganize/sanitize.go
+++ b/src/features/reorganize/sanitize.go
@@ -1,0 +1,43 @@
+package reorganize
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// fat32Forbidden contains all characters disallowed in FAT32 filenames.
+const fat32Forbidden = `:*?"<>|\`
+
+// sanitizeFAT32Path makes every segment of a file path UTF-8 valid and free of
+// FAT32-forbidden characters (: * ? " < > | \). Path separators are preserved;
+// only individual segments are processed.
+func sanitizeFAT32Path(path string) string {
+	segments := strings.Split(path, string(filepath.Separator))
+	for i, seg := range segments {
+		segments[i] = sanitizeFAT32Segment(seg)
+	}
+	return strings.Join(segments, string(filepath.Separator))
+}
+
+// sanitizeFAT32Segment cleans a single path component.
+func sanitizeFAT32Segment(seg string) string {
+	if seg == "" {
+		return seg
+	}
+	// Strip invalid UTF-8 sequences by replacing them with nothing.
+	seg = strings.ToValidUTF8(seg, "")
+	// Replace each FAT32-forbidden character with a hyphen.
+	var b strings.Builder
+	b.Grow(len(seg))
+	for _, r := range seg {
+		if strings.ContainsRune(fat32Forbidden, r) {
+			b.WriteRune('-')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	result := b.String()
+	// FAT32 names must not end with a dot or a space.
+	result = strings.TrimRight(result, ". ")
+	return result
+}

--- a/src/features/reorganize/sanitize.go
+++ b/src/features/reorganize/sanitize.go
@@ -3,29 +3,39 @@ package reorganize
 import (
 	"path/filepath"
 	"strings"
+	"unicode/utf8"
 )
 
 // fat32Forbidden contains all characters disallowed in FAT32 filenames.
 const fat32Forbidden = `:*?"<>|\`
 
+// maxFAT32Bytes is the maximum byte length of a single FAT32 filename component.
+const maxFAT32Bytes = 255
+
 // sanitizeFAT32Path makes every segment of a file path UTF-8 valid and free of
 // FAT32-forbidden characters (: * ? " < > | \). Path separators are preserved;
-// only individual segments are processed.
+// only individual segments are processed. The final segment (the filename) has
+// its extension preserved when truncating to the 255-byte FAT32 limit.
 func sanitizeFAT32Path(path string) string {
 	segments := strings.Split(path, string(filepath.Separator))
+	last := len(segments) - 1
 	for i, seg := range segments {
-		segments[i] = sanitizeFAT32Segment(seg)
+		segments[i] = sanitizeFAT32Segment(seg, i == last)
 	}
 	return strings.Join(segments, string(filepath.Separator))
 }
 
 // sanitizeFAT32Segment cleans a single path component.
-func sanitizeFAT32Segment(seg string) string {
+// isFilename should be true for the final segment so the file extension is
+// preserved when the name needs to be truncated.
+func sanitizeFAT32Segment(seg string, isFilename bool) string {
 	if seg == "" {
 		return seg
 	}
-	// Strip invalid UTF-8 sequences by replacing them with nothing.
+
+	// Strip invalid UTF-8 sequences.
 	seg = strings.ToValidUTF8(seg, "")
+
 	// Replace each FAT32-forbidden character with a hyphen.
 	var b strings.Builder
 	b.Grow(len(seg))
@@ -37,7 +47,40 @@ func sanitizeFAT32Segment(seg string) string {
 		}
 	}
 	result := b.String()
-	// FAT32 names must not end with a dot or a space.
+
+	// FAT32 names must not end with a dot or a space (applies to both files
+	// and directories; for files the extension already prevents a trailing dot
+	// under normal circumstances, but we trim here to be safe).
 	result = strings.TrimRight(result, ". ")
+
+	// Enforce the 255-byte FAT32 filename limit.
+	// For the filename segment, preserve the extension so the file remains
+	// openable even after truncation.
+	if isFilename {
+		ext := filepath.Ext(result)
+		stem := result[:len(result)-len(ext)]
+		maxStem := maxFAT32Bytes - len(ext)
+		if maxStem < 1 {
+			maxStem = 1
+		}
+		result = truncateBytesUTF8(stem, maxStem) + ext
+	} else {
+		result = truncateBytesUTF8(result, maxFAT32Bytes)
+	}
+
 	return result
+}
+
+// truncateBytesUTF8 shortens s to at most maxBytes bytes, cutting only at valid
+// UTF-8 rune boundaries so the result is always a well-formed string.
+func truncateBytesUTF8(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	truncated := s[:maxBytes]
+	// Walk back until the slice ends on a valid rune boundary.
+	for !utf8.ValidString(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
 }

--- a/src/features/reorganize/service.go
+++ b/src/features/reorganize/service.go
@@ -27,10 +27,13 @@ func NewService(lib music.Library, fileManager music.FileManager, cfg *config.Ma
 	}
 }
 
-// StartReorganizeAnalysis starts a job to reorganize all tracks based on current path configuration
-func (s *Service) StartReorganizeAnalysis(ctx context.Context) (string, error) {
-	slog.Info("Starting file reorganization job")
-	jobID, err := s.jobService.StartJob("analyze_reorganize", "Reorganize Library Files", map[string]any{})
+// StartReorganizeAnalysis starts a job to reorganize all tracks based on current path configuration.
+// When fat32Safe is true the job will also strip FAT32-forbidden characters from every path segment.
+func (s *Service) StartReorganizeAnalysis(ctx context.Context, fat32Safe bool) (string, error) {
+	slog.Info("Starting file reorganization job", "fat32Safe", fat32Safe)
+	jobID, err := s.jobService.StartJob("analyze_reorganize", "Reorganize Library Files", map[string]any{
+		"fat32_safe": fat32Safe,
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to start reorganization job: %w", err)
 	}

--- a/src/infra/files/organizer.go
+++ b/src/infra/files/organizer.go
@@ -63,6 +63,24 @@ func (o *FileOrganizer) MoveTrack(ctx context.Context, track *music.Track) (stri
 	return newPath, nil
 }
 
+// MoveTrackToPath moves a track file to an explicit destination path.
+func (o *FileOrganizer) MoveTrackToPath(ctx context.Context, track *music.Track, destPath string) (string, error) {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return "", fmt.Errorf("failed to create directory: %w", err)
+	}
+	if err := copyFile(track.Path, destPath); err != nil {
+		return "", fmt.Errorf("failed to copy file: %w", err)
+	}
+	if err := os.Remove(track.Path); err != nil {
+		return "", fmt.Errorf("failed to remove original file after copy: %w", err)
+	}
+	dir := filepath.Dir(track.Path)
+	if err := o.removeEmptyDirectories(dir); err != nil {
+		fmt.Printf("Warning: failed to clean up empty directories after move: %v\n", err)
+	}
+	return destPath, nil
+}
+
 // isCrossDeviceError checks if an error is due to cross-device link (moving across filesystems)
 func isCrossDeviceError(err error) bool {
 	return err != nil && (err.Error() == "invalid cross-device link" || err.Error() == "cross-device link")

--- a/src/infra/files/organizer.go
+++ b/src/infra/files/organizer.go
@@ -34,8 +34,8 @@ func (o *FileOrganizer) GetLibraryPath(ctx context.Context, track *music.Track) 
 	return newPath, nil
 }
 
-// MoveTrack moves a track to a new location based on its metadata.
-func (o *FileOrganizer) MoveTrack(ctx context.Context, track *music.Track) (string, error) {
+// MoveTrackToLibrary moves a track to a new location based on its metadata.
+func (o *FileOrganizer) MoveTrackToLibrary(ctx context.Context, track *music.Track) (string, error) {
 	renderedPath, err := o.pathParser.RenderPath(track)
 	if err != nil {
 		return "", fmt.Errorf("failed to render path: %w", err)
@@ -77,8 +77,8 @@ func isCrossDeviceError(err error) bool {
 	return err != nil && (err.Error() == "invalid cross-device link" || err.Error() == "cross-device link")
 }
 
-// CopyTrack copies a track to a new location based on its metadata.
-func (o *FileOrganizer) CopyTrack(ctx context.Context, track *music.Track) (string, error) {
+// CopyTrackToLibrary copies a track to a new location based on its metadata.
+func (o *FileOrganizer) CopyTrackToLibrary(ctx context.Context, track *music.Track) (string, error) {
 	renderedPath, err := o.pathParser.RenderPath(track)
 	if err != nil {
 		return "", fmt.Errorf("failed to render path: %w", err)

--- a/src/infra/files/organizer.go
+++ b/src/infra/files/organizer.go
@@ -47,9 +47,9 @@ func (o *FileOrganizer) MoveTrack(ctx context.Context, track *music.Track) (stri
 	return newPath, nil
 }
 
-// MoveTrackToPath moves a track file to an explicit destination path.
-func (o *FileOrganizer) MoveTrackToPath(ctx context.Context, track *music.Track, destPath string) (string, error) {
-	if err := o.moveFile(track.Path, destPath); err != nil {
+// MoveTrackFile moves a track file to an explicit destination path.
+func (o *FileOrganizer) MoveTrackFile(ctx context.Context, srcPath, destPath string) (string, error) {
+	if err := o.moveFile(srcPath, destPath); err != nil {
 		return "", err
 	}
 	return destPath, nil

--- a/src/infra/files/organizer.go
+++ b/src/infra/files/organizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -39,46 +40,36 @@ func (o *FileOrganizer) MoveTrack(ctx context.Context, track *music.Track) (stri
 	if err != nil {
 		return "", fmt.Errorf("failed to render path: %w", err)
 	}
-
 	newPath := filepath.Join(o.libraryPath, renderedPath+filepath.Ext(track.Path))
-	if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
-		return "", fmt.Errorf("failed to create directory: %w", err)
+	if err := o.moveFile(track.Path, newPath); err != nil {
+		return "", err
 	}
-
-	if err := copyFile(track.Path, newPath); err != nil {
-		return "", fmt.Errorf("failed to copy file: %w", err)
-	}
-	// Remove the original file after successful copy
-	if err := os.Remove(track.Path); err != nil {
-		return "", fmt.Errorf("failed to remove original file after copy: %w", err)
-	}
-
-	// Check if parent directory of original file is now empty and remove it if so
-	dir := filepath.Dir(track.Path)
-	if err := o.removeEmptyDirectories(dir); err != nil {
-		// Log warning but don't fail the operation since file move succeeded
-		fmt.Printf("Warning: failed to clean up empty directories after move: %v\n", err)
-	}
-
 	return newPath, nil
 }
 
 // MoveTrackToPath moves a track file to an explicit destination path.
 func (o *FileOrganizer) MoveTrackToPath(ctx context.Context, track *music.Track, destPath string) (string, error) {
-	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-		return "", fmt.Errorf("failed to create directory: %w", err)
-	}
-	if err := copyFile(track.Path, destPath); err != nil {
-		return "", fmt.Errorf("failed to copy file: %w", err)
-	}
-	if err := os.Remove(track.Path); err != nil {
-		return "", fmt.Errorf("failed to remove original file after copy: %w", err)
-	}
-	dir := filepath.Dir(track.Path)
-	if err := o.removeEmptyDirectories(dir); err != nil {
-		fmt.Printf("Warning: failed to clean up empty directories after move: %v\n", err)
+	if err := o.moveFile(track.Path, destPath); err != nil {
+		return "", err
 	}
 	return destPath, nil
+}
+
+// moveFile copies src to dst, removes src, and cleans up empty parent directories.
+func (o *FileOrganizer) moveFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		return fmt.Errorf("failed to copy file: %w", err)
+	}
+	if err := os.Remove(src); err != nil {
+		return fmt.Errorf("failed to remove original file after copy: %w", err)
+	}
+	if err := o.removeEmptyDirectories(filepath.Dir(src)); err != nil {
+		slog.Warn("failed to clean up empty directories after move", "error", err)
+	}
+	return nil
 }
 
 // isCrossDeviceError checks if an error is due to cross-device link (moving across filesystems)

--- a/src/infra/files/path_parser.go
+++ b/src/infra/files/path_parser.go
@@ -61,7 +61,11 @@ func (p *TemplatePathParser) renderPathTemplate(template string, track *music.Tr
 
 		switch funcName {
 		case "asciify":
-			return unidecode.Unidecode(argValue)
+			asciified := unidecode.Unidecode(argValue)
+			if len(asciified) == 0 {
+				return ""
+			}
+			return strings.ReplaceAll(asciified, "/", "-")
 		case "artistfolder":
 			asciified := unidecode.Unidecode(argValue)
 			if len(asciified) == 0 {

--- a/src/music/files.go
+++ b/src/music/files.go
@@ -10,8 +10,8 @@ type FileManager interface {
 	GetLibraryPath(ctx context.Context, track *Track) (string, error)
 	// MoveTrack moves a track to a new location based on its metadata.
 	MoveTrack(ctx context.Context, track *Track) (string, error)
-	// MoveTrackToPath moves a track file to an explicit destination path.
-	MoveTrackToPath(ctx context.Context, track *Track, destPath string) (string, error)
+	// MoveTrackFile moves a track file to an explicit destination path.
+	MoveTrackFile(ctx context.Context, srcPath, destPath string) (string, error)
 	// CopyTrack copies a track to a new location based on its metadata.
 	CopyTrack(ctx context.Context, track *Track) (string, error)
 	// DeleteTrack removes a track file from the library

--- a/src/music/files.go
+++ b/src/music/files.go
@@ -10,6 +10,8 @@ type FileManager interface {
 	GetLibraryPath(ctx context.Context, track *Track) (string, error)
 	// MoveTrack moves a track to a new location based on its metadata.
 	MoveTrack(ctx context.Context, track *Track) (string, error)
+	// MoveTrackToPath moves a track file to an explicit destination path.
+	MoveTrackToPath(ctx context.Context, track *Track, destPath string) (string, error)
 	// CopyTrack copies a track to a new location based on its metadata.
 	CopyTrack(ctx context.Context, track *Track) (string, error)
 	// DeleteTrack removes a track file from the library

--- a/src/music/files.go
+++ b/src/music/files.go
@@ -8,12 +8,12 @@ import (
 type FileManager interface {
 	// GetLibraryPath generates the library path for a track without moving it.
 	GetLibraryPath(ctx context.Context, track *Track) (string, error)
-	// MoveTrack moves a track to a new location based on its metadata.
-	MoveTrack(ctx context.Context, track *Track) (string, error)
+	// MoveTrackToLibrary moves a track to a new location based on its metadata.
+	MoveTrackToLibrary(ctx context.Context, track *Track) (string, error)
 	// MoveTrackFile moves a track file to an explicit destination path.
 	MoveTrackFile(ctx context.Context, srcPath, destPath string) (string, error)
-	// CopyTrack copies a track to a new location based on its metadata.
-	CopyTrack(ctx context.Context, track *Track) (string, error)
+	// CopyTrackToLibrary copies a track to a new location based on its metadata.
+	CopyTrackToLibrary(ctx context.Context, track *Track) (string, error)
 	// DeleteTrack removes a track file from the library
 	DeleteTrack(ctx context.Context, trackPath string) error
 }

--- a/views/jobs/job_card_footer.html
+++ b/views/jobs/job_card_footer.html
@@ -10,6 +10,13 @@
   {{ $colorClass := "bg-red-50/80 dark:bg-red-900/30 border border-red-200/60 dark:border-red-800/60 text-red-700 dark:text-red-300" }}
   {{ if eq $job.Type "analyze_lyrics" }}
     {{ $colorClass = "bg-pink-50/80 dark:bg-pink-900/30 border border-pink-200/60 dark:border-pink-800/60 text-pink-700 dark:text-pink-300" }}
+  {{ else if eq $job.Type "analyze_reorganize" }}
+    {{ $moved := index $job.Metadata "moved" }}
+    {{ if and (eq $job.Status "completed") $moved (gt $moved 0) }}
+      {{ $colorClass = "bg-green-50/80 dark:bg-green-900/30 border border-green-200/60 dark:border-green-800/60 text-green-700 dark:text-green-300" }}
+    {{ else if eq $job.Status "completed" }}
+      {{ $colorClass = "bg-blue-50/80 dark:bg-blue-900/30 border border-blue-200/60 dark:border-blue-800/60 text-blue-700 dark:text-blue-300" }}
+    {{ end }}
   {{ else if eq $job.Status "cancelled" }}
     {{ $colorClass = "bg-gray-50/80 dark:bg-gray-900/30 border border-gray-200/60 dark:border-gray-800/60 text-gray-700 dark:text-gray-300" }}
   {{ else if and (eq $job.Status "completed") $stats (gt $stats.TracksImported 0) }}

--- a/views/sections/analyze_files.html
+++ b/views/sections/analyze_files.html
@@ -16,17 +16,31 @@
             <p class="text-slate-600 dark:text-slate-400 mb-3">
                 Current path templates used for organizing files. Configure in <a href="/settings" class="text-blue-500 hover:text-blue-400 underline">Settings</a>.
             </p>
-            <button
-                hx-post="/analyze/reorganize"
-                hx-target="#toast-container"
-                hx-swap="beforeend"
-                class="w-full border border-green-500 dark:border-green-400 text-green-500 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30 font-medium py-2 px-4 rounded-md transition-colors duration-200"
-            >
-                Apply templates
-                <span class="htmx-indicator ml-2">
-                    <i class="fas fa-spinner fa-spin text-green-500 dark:text-green-400"></i>
-                </span>
-            </button>
+            <form hx-post="/analyze/reorganize" hx-target="#toast-container" hx-swap="beforeend">
+                <div class="flex items-start gap-2 mb-3">
+                    <input
+                        type="checkbox"
+                        id="fat32_safe"
+                        name="fat32_safe"
+                        value="true"
+                        class="mt-0.5 w-4 h-4 text-green-500 border-gray-300 rounded focus:ring-green-500 dark:border-gray-600 dark:bg-gray-700 shrink-0"
+                    >
+                    <label for="fat32_safe" class="text-xs text-slate-600 dark:text-slate-400">
+                        <span class="font-medium text-slate-700 dark:text-slate-300">FAT32-safe filenames</span> —
+                        strip characters forbidden on FAT32/Windows (<code class="font-mono">: * ? " &lt; &gt; | \</code>)
+                        from every path segment. Useful when syncing to an iPod or external drive.
+                    </label>
+                </div>
+                <button
+                    type="submit"
+                    class="w-full border border-green-500 dark:border-green-400 text-green-500 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30 font-medium py-2 px-4 rounded-md transition-colors duration-200"
+                >
+                    Apply templates
+                    <span class="htmx-indicator ml-2">
+                        <i class="fas fa-spinner fa-spin text-green-500 dark:text-green-400"></i>
+                    </span>
+                </button>
+            </form>
             <div class="mt-3 text-xs text-slate-500 dark:text-slate-400">
                 <a href="https://soulsolid.contre.io/docs/paths/#available-placeholders" target="_blank" class="text-blue-500 hover:text-blue-400 underline">View documentation for placeholders</a>
             </div>


### PR DESCRIPTION
Fix and extend file path reorganization job
I'm doing this primary because I want to freely use `rsync` whil synching my iPod which uses a FAT32 filesystem. Since modifying the library files might corrupt Soulsolid DB, since modifying tracks in the fs won't modified the db file path. So I'm doing it in Soulsolid.  

Fixes correctness issues in the existing reorganize job and adds FAT32-safe path sanitization for iPod/external drive syncing.

  Fixes
  - Progress bar now advances correctly — attempted counter increments for every track processed, not only on successful moves
  - Job card now shows a completion summary (paths modified / already correct / errors) via Metadata["msg"]
  - Job card appears immediately after triggering, matching the behaviour of the lyrics job (HX-Trigger: refreshJobList)
  - MoveTrackToPath added to FileManager so the job no longer re-runs the template engine on every move

  FAT32-safe mode
  - New checkbox in the Path Templates card; when checked, every path segment is stripped of FAT32-forbidden characters (: * ? " < > | \), invalid UTF-8 bytes, trailing
  dots/spaces, and truncated to the 255-byte FAT32 limit (extension preserved)
  - Reversible: re-running the job without the checkbox re-derives paths from track metadata and moves files back

  FEATURE_SPEC_KIT.md
  - Documents the "msg" metadata key requirement for job summaries
  - Documents the HX-Trigger: refreshJobList pattern for immediate job card appearance
  - Both include checklists and code examples