### PR TITLE
Streaming feature

### DIFF
--- a/src/features/hosting/server.go
+++ b/src/features/hosting/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/contre95/soulsolid/src/features/metrics"
 	"github.com/contre95/soulsolid/src/features/playlists"
 	"github.com/contre95/soulsolid/src/features/reorganize"
+	"github.com/contre95/soulsolid/src/features/streaming"
 	"github.com/contre95/soulsolid/src/features/ui"
 	"github.com/contre95/soulsolid/src/music"
 	"github.com/gofiber/fiber/v2"
@@ -29,7 +30,7 @@ type Server struct {
 }
 
 // NewServer creates a new HTTP server.
-func NewServer(cfg *config.Manager, importingService *importing.Service, libraryService *library.Service, playlistsService *playlists.Service, downloadingService *downloading.Service, jobService *jobs.Service, tagService *metadata.Service, lyricsService *lyrics.Service, metricsService *metrics.Service, reorganizeService *reorganize.Service) *Server {
+func NewServer(cfg *config.Manager, importingService *importing.Service, libraryService *library.Service, playlistsService *playlists.Service, downloadingService *downloading.Service, jobService *jobs.Service, tagService *metadata.Service, lyricsService *lyrics.Service, metricsService *metrics.Service, reorganizeService *reorganize.Service, streamingService *streaming.Service) *Server {
 	engine := html.New("./views", ".html")
 	engine.Debug(cfg.Get().Logger.Level == "debug")
 	// Add custom template functions
@@ -135,6 +136,7 @@ func NewServer(cfg *config.Manager, importingService *importing.Service, library
 	lyrics.RegisterRoutes(app, lyricsHandler)
 	reorganizeHandler := reorganize.NewHandler(reorganizeService, cfg)
 	reorganize.RegisterRoutes(app, reorganizeHandler)
+	streaming.RegisterRoutes(app, streamingService)
 
 	return &Server{app: app, port: cfg.Get().Server.Port}
 }

--- a/src/features/hosting/server.go
+++ b/src/features/hosting/server.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/contre95/soulsolid/src/features/config"
@@ -79,6 +80,7 @@ func NewServer(cfg *config.Manager, importingService *importing.Service, library
 	engine.AddFunc("capitalize", func(s string) string {
 		return strings.Title(strings.ToLower(s))
 	})
+	engine.AddFunc("pathBase", filepath.Base)
 
 	app := fiber.New(fiber.Config{
 		Views: engine,

--- a/src/features/hosting/server.go
+++ b/src/features/hosting/server.go
@@ -3,6 +3,7 @@ package hosting
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -81,6 +82,7 @@ func NewServer(cfg *config.Manager, importingService *importing.Service, library
 		return strings.Title(strings.ToLower(s))
 	})
 	engine.AddFunc("pathBase", filepath.Base)
+	engine.AddFunc("urlEncode", url.QueryEscape)
 
 	app := fiber.New(fiber.Config{
 		Views: engine,

--- a/src/features/importing/service.go
+++ b/src/features/importing/service.go
@@ -78,6 +78,18 @@ func (s *Service) GetQueuedItems() map[string]music.QueueItem {
 	return s.queue.GetAll()
 }
 
+// GetPendingTrackPath returns the file path of a pending track in the import queue.
+func (s *Service) GetPendingTrackPath(itemID string) (string, error) {
+	item, err := s.queue.GetByID(itemID)
+	if err != nil {
+		return "", fmt.Errorf("queue item not found: %w", err)
+	}
+	if item.Track == nil {
+		return "", fmt.Errorf("queue item has no track")
+	}
+	return item.Track.Path, nil
+}
+
 // GetPendingTrackArtwork returns the embedded artwork for a pending (not yet imported) track file.
 func (s *Service) GetPendingTrackArtwork(itemID string) ([]byte, string, error) {
 	item, err := s.queue.GetByID(itemID)

--- a/src/features/library/service.go
+++ b/src/features/library/service.go
@@ -392,6 +392,18 @@ func (s *Service) GetTrack(ctx context.Context, id string) (*library.Track, erro
 	return track, nil
 }
 
+// GetLibraryTrackPath returns the file path of an imported library track.
+func (s *Service) GetLibraryTrackPath(ctx context.Context, trackID string) (string, error) {
+	track, err := s.library.GetTrack(ctx, trackID)
+	if err != nil {
+		return "", fmt.Errorf("track not found: %w", err)
+	}
+	if track == nil {
+		return "", fmt.Errorf("track not found")
+	}
+	return track.Path, nil
+}
+
 // GetArtistByName finds an artist by name without creating it.
 func (s *Service) GetArtistByName(ctx context.Context, artistName string) (*library.Artist, error) {
 	artist, err := s.library.GetArtistByName(ctx, artistName)

--- a/src/features/streaming/handlers.go
+++ b/src/features/streaming/handlers.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"log/slog"
+	"net/url"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -16,28 +17,19 @@ func NewHandler(service *Service) *Handler {
 	return &Handler{service: service}
 }
 
-// StreamQueueItem streams a pending track from the download folder.
-func (h *Handler) StreamQueueItem(c *fiber.Ctx) error {
-	id := c.Params("id")
-	path, mimeType, err := h.service.QueueTrackStream(id)
+// Stream serves the file at the given path query parameter.
+func (h *Handler) Stream(c *fiber.Ctx) error {
+	rawPath := c.Query("path")
+	path, err := url.QueryUnescape(rawPath)
 	if err != nil {
-		slog.Error("StreamQueueItem: failed to resolve path", "id", id, "error", err)
+		return c.Status(fiber.StatusBadRequest).SendString("invalid path")
+	}
+	resolved, mimeType, err := h.service.Stream(path)
+	if err != nil {
+		slog.Error("Stream: rejected path", "path", path, "error", err)
 		return c.Status(fiber.StatusNotFound).SendString("track not found")
 	}
 	c.Set("Content-Type", mimeType)
 	c.Set("Accept-Ranges", "bytes")
-	return c.SendFile(path)
-}
-
-// StreamLibraryTrack streams an imported library track.
-func (h *Handler) StreamLibraryTrack(c *fiber.Ctx) error {
-	id := c.Params("id")
-	path, mimeType, err := h.service.LibraryTrackStream(c.Context(), id)
-	if err != nil {
-		slog.Error("StreamLibraryTrack: failed to resolve path", "id", id, "error", err)
-		return c.Status(fiber.StatusNotFound).SendString("track not found")
-	}
-	c.Set("Content-Type", mimeType)
-	c.Set("Accept-Ranges", "bytes")
-	return c.SendFile(path)
+	return c.SendFile(resolved)
 }

--- a/src/features/streaming/handlers.go
+++ b/src/features/streaming/handlers.go
@@ -1,0 +1,43 @@
+package streaming
+
+import (
+	"log/slog"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// Handler handles audio streaming requests.
+type Handler struct {
+	service *Service
+}
+
+// NewHandler creates a new streaming handler.
+func NewHandler(service *Service) *Handler {
+	return &Handler{service: service}
+}
+
+// StreamQueueItem streams a pending track from the download folder.
+func (h *Handler) StreamQueueItem(c *fiber.Ctx) error {
+	id := c.Params("id")
+	path, mimeType, err := h.service.QueueTrackStream(id)
+	if err != nil {
+		slog.Error("StreamQueueItem: failed to resolve path", "id", id, "error", err)
+		return c.Status(fiber.StatusNotFound).SendString("track not found")
+	}
+	c.Set("Content-Type", mimeType)
+	c.Set("Accept-Ranges", "bytes")
+	return c.SendFile(path)
+}
+
+// StreamLibraryTrack streams an imported library track.
+func (h *Handler) StreamLibraryTrack(c *fiber.Ctx) error {
+	id := c.Params("id")
+	path, mimeType, err := h.service.LibraryTrackStream(c.Context(), id)
+	if err != nil {
+		slog.Error("StreamLibraryTrack: failed to resolve path", "id", id, "error", err)
+		return c.Status(fiber.StatusNotFound).SendString("track not found")
+	}
+	c.Set("Content-Type", mimeType)
+	c.Set("Accept-Ranges", "bytes")
+	return c.SendFile(path)
+}

--- a/src/features/streaming/routes.go
+++ b/src/features/streaming/routes.go
@@ -1,0 +1,10 @@
+package streaming
+
+import "github.com/gofiber/fiber/v2"
+
+// RegisterRoutes registers the audio streaming routes.
+func RegisterRoutes(app *fiber.App, service *Service) {
+	handler := NewHandler(service)
+	app.Get("/stream/queue/:id", handler.StreamQueueItem)
+	app.Get("/stream/library/:id", handler.StreamLibraryTrack)
+}

--- a/src/features/streaming/routes.go
+++ b/src/features/streaming/routes.go
@@ -5,6 +5,5 @@ import "github.com/gofiber/fiber/v2"
 // RegisterRoutes registers the audio streaming routes.
 func RegisterRoutes(app *fiber.App, service *Service) {
 	handler := NewHandler(service)
-	app.Get("/stream/queue/:id", handler.StreamQueueItem)
-	app.Get("/stream/library/:id", handler.StreamLibraryTrack)
+	app.Get("/stream", handler.Stream)
 }

--- a/src/features/streaming/service.go
+++ b/src/features/streaming/service.go
@@ -1,0 +1,57 @@
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/contre95/soulsolid/src/features/config"
+)
+
+// Service handles audio streaming from both the download folder and the library.
+type Service struct {
+	queue   QueueLocator
+	library LibraryLocator
+	cfg     *config.Manager
+}
+
+// NewService creates a new streaming service.
+func NewService(queue QueueLocator, library LibraryLocator, cfg *config.Manager) *Service {
+	return &Service{queue: queue, library: library, cfg: cfg}
+}
+
+// QueueTrackStream returns the validated file path and MIME type for a pending queue item.
+func (s *Service) QueueTrackStream(itemID string) (string, string, error) {
+	path, err := s.queue.GetPendingTrackPath(itemID)
+	if err != nil {
+		return "", "", fmt.Errorf("queue item not found: %w", err)
+	}
+	downloadPath := filepath.Clean(s.cfg.Get().DownloadPath)
+	if !strings.HasPrefix(filepath.Clean(path), downloadPath+string(filepath.Separator)) &&
+		filepath.Clean(path) != downloadPath {
+		return "", "", fmt.Errorf("track path outside allowed directory")
+	}
+	return path, mimeTypeFor(path), nil
+}
+
+// LibraryTrackStream returns the validated file path and MIME type for a library track.
+func (s *Service) LibraryTrackStream(ctx context.Context, trackID string) (string, string, error) {
+	path, err := s.library.GetLibraryTrackPath(ctx, trackID)
+	if err != nil {
+		return "", "", fmt.Errorf("track not found: %w", err)
+	}
+	libraryPath := filepath.Clean(s.cfg.Get().LibraryPath)
+	if !strings.HasPrefix(filepath.Clean(path), libraryPath+string(filepath.Separator)) &&
+		filepath.Clean(path) != libraryPath {
+		return "", "", fmt.Errorf("track path outside allowed directory")
+	}
+	return path, mimeTypeFor(path), nil
+}
+
+func mimeTypeFor(path string) string {
+	if strings.HasSuffix(strings.ToLower(path), ".flac") {
+		return "audio/flac"
+	}
+	return "audio/mpeg"
+}

--- a/src/features/streaming/service.go
+++ b/src/features/streaming/service.go
@@ -9,6 +9,23 @@ import (
 	"github.com/contre95/soulsolid/src/features/config"
 )
 
+// containedIn resolves symlinks on both paths and checks that candidate is
+// inside (or equal to) base, preventing symlink escapes.
+func containedIn(candidate, base string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(filepath.Clean(candidate))
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve path: %w", err)
+	}
+	resolvedBase, err := filepath.EvalSymlinks(filepath.Clean(base))
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve base path: %w", err)
+	}
+	if resolved != resolvedBase && !strings.HasPrefix(resolved, resolvedBase+string(filepath.Separator)) {
+		return "", fmt.Errorf("track path outside allowed directory")
+	}
+	return resolved, nil
+}
+
 // Service handles audio streaming from both the download folder and the library.
 type Service struct {
 	queue   QueueLocator
@@ -27,12 +44,11 @@ func (s *Service) QueueTrackStream(itemID string) (string, string, error) {
 	if err != nil {
 		return "", "", fmt.Errorf("queue item not found: %w", err)
 	}
-	downloadPath := filepath.Clean(s.cfg.Get().DownloadPath)
-	if !strings.HasPrefix(filepath.Clean(path), downloadPath+string(filepath.Separator)) &&
-		filepath.Clean(path) != downloadPath {
-		return "", "", fmt.Errorf("track path outside allowed directory")
+	resolved, err := containedIn(path, s.cfg.Get().DownloadPath)
+	if err != nil {
+		return "", "", err
 	}
-	return path, mimeTypeFor(path), nil
+	return resolved, mimeTypeFor(resolved), nil
 }
 
 // LibraryTrackStream returns the validated file path and MIME type for a library track.
@@ -41,17 +57,18 @@ func (s *Service) LibraryTrackStream(ctx context.Context, trackID string) (strin
 	if err != nil {
 		return "", "", fmt.Errorf("track not found: %w", err)
 	}
-	libraryPath := filepath.Clean(s.cfg.Get().LibraryPath)
-	if !strings.HasPrefix(filepath.Clean(path), libraryPath+string(filepath.Separator)) &&
-		filepath.Clean(path) != libraryPath {
-		return "", "", fmt.Errorf("track path outside allowed directory")
+	resolved, err := containedIn(path, s.cfg.Get().LibraryPath)
+	if err != nil {
+		return "", "", err
 	}
-	return path, mimeTypeFor(path), nil
+	return resolved, mimeTypeFor(resolved), nil
 }
 
 func mimeTypeFor(path string) string {
-	if strings.HasSuffix(strings.ToLower(path), ".flac") {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".flac":
 		return "audio/flac"
+	default:
+		return "audio/mpeg"
 	}
-	return "audio/mpeg"
 }

--- a/src/features/streaming/service.go
+++ b/src/features/streaming/service.go
@@ -36,24 +36,31 @@ func NewService(cfg *config.Manager) *Service {
 	return &Service{cfg: cfg}
 }
 
-// Stream validates that path is within the library or download directory and
-// returns the resolved path and MIME type.
+var audioMIME = map[string]string{
+	".mp3":  "audio/mpeg",
+	".flac": "audio/flac",
+	// Not supported in soulsolid yet
+	".wav":  "audio/wav",
+	".aac":  "audio/aac",
+	".m4a":  "audio/mp4",
+	".ogg":  "audio/ogg",
+	".opus": "audio/ogg",
+	".wma":  "audio/x-ms-wma",
+}
+
+// Stream validates that path is within the library or download directory,
+// has an allowed audio extension, and returns the resolved path and MIME type.
 func (s *Service) Stream(path string) (string, string, error) {
 	cfg := s.cfg.Get()
 	for _, base := range []string{cfg.LibraryPath, cfg.DownloadPath} {
 		resolved, err := containedIn(path, base)
 		if err == nil {
-			return resolved, mimeTypeFor(resolved), nil
+			mime, ok := audioMIME[strings.ToLower(filepath.Ext(resolved))]
+			if !ok {
+				return "", "", fmt.Errorf("unsupported file type")
+			}
+			return resolved, mime, nil
 		}
 	}
 	return "", "", fmt.Errorf("track path outside allowed directories")
-}
-
-func mimeTypeFor(path string) string {
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".flac":
-		return "audio/flac"
-	default:
-		return "audio/mpeg"
-	}
 }

--- a/src/features/streaming/service.go
+++ b/src/features/streaming/service.go
@@ -1,7 +1,6 @@
 package streaming
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -26,42 +25,27 @@ func containedIn(candidate, base string) (string, error) {
 	return resolved, nil
 }
 
-// Service handles audio streaming from both the download folder and the library.
+// Service handles audio streaming by validating and serving file paths.
 type Service struct {
-	queue   QueueLocator
-	library LibraryLocator
-	cfg     *config.Manager
+	cfg *config.Manager
 }
 
 // NewService creates a new streaming service.
-func NewService(queue QueueLocator, library LibraryLocator, cfg *config.Manager) *Service {
-	return &Service{queue: queue, library: library, cfg: cfg}
+func NewService(cfg *config.Manager) *Service {
+	return &Service{cfg: cfg}
 }
 
-// QueueTrackStream returns the validated file path and MIME type for a pending queue item.
-func (s *Service) QueueTrackStream(itemID string) (string, string, error) {
-	path, err := s.queue.GetPendingTrackPath(itemID)
-	if err != nil {
-		return "", "", fmt.Errorf("queue item not found: %w", err)
+// Stream validates that path is within the library or download directory and
+// returns the resolved path and MIME type.
+func (s *Service) Stream(path string) (string, string, error) {
+	cfg := s.cfg.Get()
+	for _, base := range []string{cfg.LibraryPath, cfg.DownloadPath} {
+		resolved, err := containedIn(path, base)
+		if err == nil {
+			return resolved, mimeTypeFor(resolved), nil
+		}
 	}
-	resolved, err := containedIn(path, s.cfg.Get().DownloadPath)
-	if err != nil {
-		return "", "", err
-	}
-	return resolved, mimeTypeFor(resolved), nil
-}
-
-// LibraryTrackStream returns the validated file path and MIME type for a library track.
-func (s *Service) LibraryTrackStream(ctx context.Context, trackID string) (string, string, error) {
-	path, err := s.library.GetLibraryTrackPath(ctx, trackID)
-	if err != nil {
-		return "", "", fmt.Errorf("track not found: %w", err)
-	}
-	resolved, err := containedIn(path, s.cfg.Get().LibraryPath)
-	if err != nil {
-		return "", "", err
-	}
-	return resolved, mimeTypeFor(resolved), nil
+	return "", "", fmt.Errorf("track path outside allowed directories")
 }
 
 func mimeTypeFor(path string) string {

--- a/src/features/streaming/service.go
+++ b/src/features/streaming/service.go
@@ -8,8 +8,9 @@ import (
 	"github.com/contre95/soulsolid/src/features/config"
 )
 
-// containedIn resolves symlinks on both paths and checks that candidate is
-// inside (or equal to) base, preventing symlink escapes.
+// containedIn guards against path traversal attacks: it resolves symlinks on
+// both paths before the prefix check, so neither ../.. sequences nor symlinks
+// inside the allowed directory can be used to escape it and read arbitrary files.
 func containedIn(candidate, base string) (string, error) {
 	resolved, err := filepath.EvalSymlinks(filepath.Clean(candidate))
 	if err != nil {

--- a/src/features/streaming/streaming.go
+++ b/src/features/streaming/streaming.go
@@ -1,1 +1,0 @@
-package streaming

--- a/src/features/streaming/streaming.go
+++ b/src/features/streaming/streaming.go
@@ -1,0 +1,13 @@
+package streaming
+
+import "context"
+
+// QueueLocator resolves a pending (not yet imported) track file path from the import queue.
+type QueueLocator interface {
+	GetPendingTrackPath(itemID string) (string, error)
+}
+
+// LibraryLocator resolves an imported track file path from the library.
+type LibraryLocator interface {
+	GetLibraryTrackPath(ctx context.Context, trackID string) (string, error)
+}

--- a/src/features/streaming/streaming.go
+++ b/src/features/streaming/streaming.go
@@ -1,13 +1,1 @@
 package streaming
-
-import "context"
-
-// QueueLocator resolves a pending (not yet imported) track file path from the import queue.
-type QueueLocator interface {
-	GetPendingTrackPath(itemID string) (string, error)
-}
-
-// LibraryLocator resolves an imported track file path from the library.
-type LibraryLocator interface {
-	GetLibraryTrackPath(ctx context.Context, trackID string) (string, error)
-}

--- a/src/main.go
+++ b/src/main.go
@@ -134,7 +134,7 @@ func main() {
 		}
 	}
 
-	streamingService := streaming.NewService(importingService, libraryService, cfgManager)
+	streamingService := streaming.NewService(cfgManager)
 	server := hosting.NewServer(cfgManager, importingService, libraryService, playlistsService, downloadingService, jobService, tagService, lyricsService, metricsService, reorganizeService, streamingService)
 	slog.Info("Starting server", "port", cfgManager.Get().Server.Port)
 	if err := server.Start(); err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/contre95/soulsolid/src/features/metrics"
 	"github.com/contre95/soulsolid/src/features/playlists"
 	"github.com/contre95/soulsolid/src/features/reorganize"
+	"github.com/contre95/soulsolid/src/features/streaming"
 	"github.com/contre95/soulsolid/src/infra/database"
 	"github.com/contre95/soulsolid/src/infra/files"
 	"github.com/contre95/soulsolid/src/infra/fingerprint"
@@ -133,7 +134,8 @@ func main() {
 		}
 	}
 
-	server := hosting.NewServer(cfgManager, importingService, libraryService, playlistsService, downloadingService, jobService, tagService, lyricsService, metricsService, reorganizeService)
+	streamingService := streaming.NewService(importingService, libraryService, cfgManager)
+	server := hosting.NewServer(cfgManager, importingService, libraryService, playlistsService, downloadingService, jobService, tagService, lyricsService, metricsService, reorganizeService, streamingService)
 	slog.Info("Starting server", "port", cfgManager.Get().Server.Port)
 	if err := server.Start(); err != nil {
 		slog.Error("server stopped: %v", "error", err)

--- a/views/importing/queue_header.html
+++ b/views/importing/queue_header.html
@@ -10,7 +10,7 @@
          hx-swap="innerHTML"
          hx-trigger="updateQueueCount from:body"
          class="text-sm text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full">
-         {{.QueueCount}} items
+         {{.QueueCount}}
        </span>
     </h2>
      <div class="flex flex-row gap-2 justify-center flex-1">

--- a/views/importing/queue_items.html
+++ b/views/importing/queue_items.html
@@ -45,6 +45,51 @@
             </div>
         </div>
 
+         <!-- Audio players -->
+         {{if eq .Type "duplicate"}}
+         <div class="flex flex-wrap items-center gap-2">
+             <button _="on click toggle .hidden on #player-queue-{{.ID}}"
+                 class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
+                 <i class="fas fa-music fa-xs"></i> New
+             </button>
+             <button _="on click toggle .hidden on #player-lib-{{.ID}}"
+                 class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-300 hover:bg-blue-500/20 transition-colors">
+                 <i class="fas fa-music fa-xs"></i> Existing
+             </button>
+         </div>
+         <div id="player-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2.5 bg-violet-500/5 border border-violet-400/20 rounded-lg px-3 py-2 w-full">
+             <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-violet-500/20 hover:bg-violet-500/40 text-violet-600 dark:text-violet-300 transition-colors">
+                 <i class="fas fa-play fa-xs"></i>
+             </button>
+             <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
+             <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+             <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+         </div>
+         <div id="player-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2.5 bg-blue-500/5 border border-blue-400/20 rounded-lg px-3 py-2 w-full">
+             <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
+                 <i class="fas fa-play fa-xs"></i>
+             </button>
+             <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
+             <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+             <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+         </div>
+         {{else}}
+         <div class="flex items-center gap-2">
+             <button _="on click toggle .hidden on #player-queue-{{.ID}}"
+                 class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-gray-500/10 border border-gray-400/30 text-gray-600 dark:text-gray-300 hover:bg-gray-500/20 transition-colors">
+                 <i class="fas fa-music fa-xs"></i> Play
+             </button>
+         </div>
+         <div id="player-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2.5 bg-gray-500/5 border border-gray-400/20 rounded-lg px-3 py-2 w-full">
+             <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-gray-500/20 hover:bg-gray-500/40 text-gray-600 dark:text-gray-300 transition-colors">
+                 <i class="fas fa-play fa-xs"></i>
+             </button>
+             <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
+             <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+             <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+         </div>
+         {{end}}
+
          <!-- Details row -->
          <div class="text-xs text-gray-600 dark:text-gray-400 space-y-0.5">
              <p><strong>ID:</strong> <code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-xs">{{.ID}}</code></p>

--- a/views/importing/queue_items.html
+++ b/views/importing/queue_items.html
@@ -63,7 +63,7 @@
              </button>
              <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
              <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-             <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+             <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
          </div>
          <div id="player-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2.5 bg-blue-500/5 border border-blue-400/20 rounded-lg px-3 py-2 w-full">
              <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
@@ -71,7 +71,7 @@
              </button>
              <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
              <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-             <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+             <audio src="/stream?path={{urlEncode (index .ItemMetadata "duplicate_path")}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
          </div>
          {{else}}
          <div class="flex items-center gap-2">
@@ -86,7 +86,7 @@
              </button>
              <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
              <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-             <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+             <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
          </div>
          {{end}}
 

--- a/views/importing/queue_items.html
+++ b/views/importing/queue_items.html
@@ -95,10 +95,10 @@
              <p><strong>ID:</strong> <code class="bg-gray-100 dark:bg-gray-800 px-1 py-0.5 rounded text-xs">{{.ID}}</code></p>
              <p><strong>Artists ({{len .Track.Artists}}):</strong> {{if .Track.Artists}}{{range $i, $ar := .Track.Artists}}{{if $i}}, {{end}}{{$ar.Artist.Name}}{{end}}{{end}}</p>
              <p><strong>Album:</strong> {{with .Track.Album}}{{.Title}}{{else}}Unknown Album{{end}}</p>
-             <p><strong>Original path:</strong> {{.Track.Path}}</p>
+             <p><strong>New:</strong> {{.Track.Path}}</p>
               {{if len .ItemMetadata}}
                {{range $key, $value := .ItemMetadata}}
-               <p class="text-gray-600 dark:text-gray-400"><strong>{{$key}}:</strong> {{$value}}</p>
+               <p class="text-gray-600 dark:text-gray-400"><strong>{{if eq $key "duplicate_path"}}Existing{{else}}{{$key}}{{end}}:</strong> {{$value}}</p>
                {{end}}
                {{end}}
          </div>

--- a/views/importing/queue_items_grouped_album.html
+++ b/views/importing/queue_items_grouped_album.html
@@ -125,6 +125,50 @@
                               {{end}}
                         </div>
                     </div>
+                    <!-- Audio players -->
+                    {{if eq .Type "duplicate"}}
+                    <div class="flex flex-wrap items-center gap-1.5">
+                        <button _="on click toggle .hidden on #pa-queue-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> New
+                        </button>
+                        <button _="on click toggle .hidden on #pa-lib-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-300 hover:bg-blue-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> Existing
+                        </button>
+                    </div>
+                    <div id="pa-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-violet-500/5 border border-violet-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-violet-500/20 hover:bg-violet-500/40 text-violet-600 dark:text-violet-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    <div id="pa-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-blue-500/5 border border-blue-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    {{else}}
+                    <div class="flex items-center gap-1.5">
+                        <button _="on click toggle .hidden on #pa-queue-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-gray-500/10 border border-gray-400/30 text-gray-600 dark:text-gray-300 hover:bg-gray-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> Play
+                        </button>
+                    </div>
+                    <div id="pa-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-gray-500/5 border border-gray-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-gray-500/20 hover:bg-gray-500/40 text-gray-600 dark:text-gray-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    {{end}}
                     <!-- Per-item actions -->
                     <div class="flex flex-wrap gap-1.5">
                         {{if eq .Type "duplicate"}}

--- a/views/importing/queue_items_grouped_album.html
+++ b/views/importing/queue_items_grouped_album.html
@@ -143,7 +143,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     <div id="pa-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-blue-500/5 border border-blue-400/20 rounded-lg px-2.5 py-1.5 w-full">
                         <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
@@ -151,7 +151,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode (index .ItemMetadata "duplicate_path")}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     {{else}}
                     <div class="flex items-center gap-1.5">
@@ -166,7 +166,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     {{end}}
                     <!-- Per-item actions -->

--- a/views/importing/queue_items_grouped_artist.html
+++ b/views/importing/queue_items_grouped_artist.html
@@ -123,6 +123,50 @@
                               {{end}}
                         </div>
                     </div>
+                    <!-- Audio players -->
+                    {{if eq .Type "duplicate"}}
+                    <div class="flex flex-wrap items-center gap-1.5">
+                        <button _="on click toggle .hidden on #pg-queue-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> New
+                        </button>
+                        <button _="on click toggle .hidden on #pg-lib-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-300 hover:bg-blue-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> Existing
+                        </button>
+                    </div>
+                    <div id="pg-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-violet-500/5 border border-violet-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-violet-500/20 hover:bg-violet-500/40 text-violet-600 dark:text-violet-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    <div id="pg-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-blue-500/5 border border-blue-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    {{else}}
+                    <div class="flex items-center gap-1.5">
+                        <button _="on click toggle .hidden on #pg-queue-{{.ID}}"
+                            class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-gray-500/10 border border-gray-400/30 text-gray-600 dark:text-gray-300 hover:bg-gray-500/20 transition-colors">
+                            <i class="fas fa-music fa-xs"></i> Play
+                        </button>
+                    </div>
+                    <div id="pg-queue-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-gray-500/5 border border-gray-400/20 rounded-lg px-2.5 py-1.5 w-full">
+                        <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-gray-500/20 hover:bg-gray-500/40 text-gray-600 dark:text-gray-300 transition-colors">
+                            <i class="fas fa-play fa-xs"></i>
+                        </button>
+                        <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
+                        <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
+                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                    </div>
+                    {{end}}
                     <!-- Per-item actions -->
                     <div class="flex flex-wrap gap-1.5">
                         {{if eq .Type "duplicate"}}

--- a/views/importing/queue_items_grouped_artist.html
+++ b/views/importing/queue_items_grouped_artist.html
@@ -141,7 +141,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#463371] mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     <div id="pg-lib-{{.ID}}" class="audio-player hidden flex items-center gap-2 bg-blue-500/5 border border-blue-400/20 rounded-lg px-2.5 py-1.5 w-full">
                         <button onclick="toggleAudioPlayer(this)" class="play-btn flex-shrink-0 w-5 h-5 flex items-center justify-center rounded-full bg-blue-500/20 hover:bg-blue-500/40 text-blue-600 dark:text-blue-300 transition-colors">
@@ -149,7 +149,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-[#7BAADF] mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/library/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode (index .ItemMetadata "duplicate_path")}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     {{else}}
                     <div class="flex items-center gap-1.5">
@@ -164,7 +164,7 @@
                         </button>
                         <input type="range" oninput="seekAudioProgress(this)" class="flex-1 h-1 rounded-full cursor-pointer accent-gray-500 mx-1" value="0" min="0" max="100" step="0.1">
                         <span class="time-display text-xs text-gray-500 dark:text-gray-400 tabular-nums w-8 text-right flex-shrink-0">0:00</span>
-                        <audio src="/stream/queue/{{.ID}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
+                        <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none" ontimeupdate="updateAudioProgress(this)" onended="resetAudioPlayer(this)"></audio>
                     </div>
                     {{end}}
                     <!-- Per-item actions -->

--- a/views/library/track_overview_panel.html
+++ b/views/library/track_overview_panel.html
@@ -30,7 +30,7 @@
              class="flex-1 h-1 mx-1 accent-gray-500 cursor-pointer"
              oninput="seekAudioProgress(this)">
       <span class="time-display text-xs text-gray-500 dark:text-gray-400 w-8 text-right tabular-nums flex-shrink-0">0:00</span>
-      <audio src="/stream/library/{{.Track.ID}}" preload="none"
+      <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none"
              ontimeupdate="updateAudioProgress(this)"
              onended="resetAudioPlayer(this)"></audio>
     </div>

--- a/views/library/track_overview_panel.html
+++ b/views/library/track_overview_panel.html
@@ -20,6 +20,21 @@
            onerror="this.parentElement.style.display='none'">
     </div>
 
+    <!-- Audio Player -->
+    <div class="audio-player px-4 py-3 border-b border-gray-200 dark:border-gray-800 flex items-center gap-2 shrink-0">
+      <button type="button" onclick="toggleAudioPlayer(this)"
+              class="play-btn flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 flex items-center justify-center transition-colors">
+        <i class="fas fa-play fa-xs text-gray-700 dark:text-gray-200"></i>
+      </button>
+      <input type="range" min="0" max="100" value="0" step="0.1"
+             class="flex-1 h-1 mx-1 accent-gray-500 cursor-pointer"
+             oninput="seekAudioProgress(this)">
+      <span class="time-display text-xs text-gray-500 dark:text-gray-400 w-8 text-right tabular-nums flex-shrink-0">0:00</span>
+      <audio src="/stream/library/{{.Track.ID}}" preload="none"
+             ontimeupdate="updateAudioProgress(this)"
+             onended="resetAudioPlayer(this)"></audio>
+    </div>
+
     <!-- Core Info -->
     <div class="p-4 space-y-4 flex-1">
       <div>

--- a/views/partials/navbar.html
+++ b/views/partials/navbar.html
@@ -58,7 +58,7 @@
                   </svg>
                   <span class="mx-2 font-medium">Importing</span>
                   <div id="import-queue-badge-nav" hx-get="/import/queue/count" hx-push-url="false"
-                    hx-trigger="load, every 1s, refreshImportQueueBadge from:body" hx-target="#import-queue-count-nav"
+                    hx-trigger="load, every 15s, refreshImportQueueBadge from:body" hx-target="#import-queue-count-nav"
                     hx-swap="innerHTML">
                     <span id="import-queue-count-nav"
                       class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-orange-300 dark:drop-shadow-[0_0_10px_rgba(255,165,0,0.8)]"></span>
@@ -97,7 +97,7 @@
                 <div id="lyrics-queue-badge-nav"
                     hx-get="/lyrics/queue/count"
                     hx-push-url="false"
-                    hx-trigger="load, every 1s, refreshLyricsQueueBadge from:body"
+                    hx-trigger="load, every 15s, refreshLyricsQueueBadge from:body"
                     hx-target="#lyrics-queue-count-nav"
                     hx-swap="innerHTML">
                   <span id="lyrics-queue-count-nav" class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-purple-300 dark:drop-shadow-[0_0_10px_rgba(147,51,234,0.8)]"></span>
@@ -136,7 +136,7 @@
                     <div id="lyrics-queue-badge-sub"
                         hx-get="/lyrics/queue/count"
                         hx-push-url="false"
-                        hx-trigger="load, every 1s, refreshLyricsQueueBadge from:body"
+                        hx-trigger="load, every 15s, refreshLyricsQueueBadge from:body"
                         hx-target="#lyrics-queue-count-sub"
                         hx-swap="innerHTML">
                       <span id="lyrics-queue-count-sub" class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-purple-300 dark:drop-shadow-[0_0_10px_rgba(147,51,234,0.8)]"></span>
@@ -196,7 +196,7 @@
                <div id="active-jobs-badge"
                     hx-get="/ui/jobs/count?filter=active"
                    hx-push-url="false"
-                   hx-trigger="load, every 1s, refreshActiveJobsBadge from:body"
+                   hx-trigger="load, every 5s, refreshActiveJobsBadge from:body"
                    hx-target="#active-jobs-count-nav"
                    hx-swap="innerHTML">
                  <span id="active-jobs-count-nav" class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-blue-300 dark:drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]"></span>

--- a/views/partials/scripts.html
+++ b/views/partials/scripts.html
@@ -139,6 +139,60 @@
     document.getElementById('toast-container').appendChild(el);
   }
 
+  // Audio player controls
+  function toggleAudioPlayer(playBtn) {
+    var player = playBtn.closest('.audio-player');
+    var audio = player.querySelector('audio');
+    var icon = playBtn.querySelector('i');
+    if (audio.paused) {
+      document.querySelectorAll('.audio-player audio').forEach(function(a) {
+        if (a !== audio && !a.paused) {
+          a.pause();
+          var p = a.closest('.audio-player');
+          if (p) {
+            var bi = p.querySelector('.play-btn i');
+            if (bi) bi.className = 'fas fa-play fa-xs';
+          }
+        }
+      });
+      audio.play();
+      icon.className = 'fas fa-pause fa-xs';
+    } else {
+      audio.pause();
+      icon.className = 'fas fa-play fa-xs';
+    }
+  }
+
+  function updateAudioProgress(audio) {
+    if (!audio.duration) return;
+    var player = audio.closest('.audio-player');
+    if (!player) return;
+    var range = player.querySelector('input[type=range]');
+    if (range) range.value = (audio.currentTime / audio.duration) * 100;
+    var timeEl = player.querySelector('.time-display');
+    if (timeEl) {
+      var s = Math.floor(audio.currentTime);
+      timeEl.textContent = Math.floor(s / 60) + ':' + String(s % 60).padStart(2, '0');
+    }
+  }
+
+  function seekAudioProgress(rangeEl) {
+    var player = rangeEl.closest('.audio-player');
+    var audio = player.querySelector('audio');
+    if (audio.duration) audio.currentTime = (rangeEl.value / 100) * audio.duration;
+  }
+
+  function resetAudioPlayer(audio) {
+    var player = audio.closest('.audio-player');
+    if (!player) return;
+    var bi = player.querySelector('.play-btn i');
+    if (bi) bi.className = 'fas fa-play fa-xs';
+    var range = player.querySelector('input[type=range]');
+    if (range) range.value = 0;
+    var timeEl = player.querySelector('.time-display');
+    if (timeEl) timeEl.textContent = '0:00';
+  }
+
   // Lyrics-specific grouping (matches queue_header.html IDs)
   function activateLyricsGroupingButton(groupingType) {
     const idMap = {

--- a/views/partials/scripts.html
+++ b/views/partials/scripts.html
@@ -82,9 +82,6 @@
   document.addEventListener("htmx:afterSettle", function (event) {
     // Re-process HTMX on queue content and main area for dynamic buttons
     if (event.target) {
-      if (event.target.id === "contenido" || event.target.id === "lyrics-queue-content" || event.target.id === "queue-content") {
-        htmx.process(event.target);
-      }
       if (event.target.id === "contenido") {
         initSlimSelect();
       }

--- a/views/partials/sidebar.html
+++ b/views/partials/sidebar.html
@@ -51,7 +51,7 @@
                   </svg>
                   <span class="mx-2 mr-2 font-medium">Importing</span>
                   <div id="import-queue-badge" hx-get="/import/queue/count" hx-push-url="false"
-                    hx-trigger="load, every 1s, refreshImportQueueBadge from:body" hx-target="#import-queue-count"
+                    hx-trigger="load, every 15s, refreshImportQueueBadge from:body" hx-target="#import-queue-count"
                     hx-swap="innerHTML">
                     <span id="import-queue-count"
                       class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-orange-300 dark:drop-shadow-[0_0_10px_rgba(255,165,0,0.8)]"></span>
@@ -114,7 +114,7 @@
                 </svg>
                 <span class="mx-2 mr-2 font-medium">Lyrics</span>
                   <div id="lyrics-queue-badge" hx-get="/lyrics/queue/count" hx-push-url="false"
-                    hx-trigger="load, every 1s, refreshLyricsQueueBadge from:body" hx-target="#lyrics-queue-count"
+                    hx-trigger="load, every 15s, refreshLyricsQueueBadge from:body" hx-target="#lyrics-queue-count"
                     hx-swap="innerHTML">
                     <span id="lyrics-queue-count"
                       class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-purple-300 dark:drop-shadow-[0_0_10px_rgba(147,51,234,0.8)]"></span>
@@ -165,7 +165,7 @@
             </svg>
             <span class="mx-4 mr-2">All Jobs</span>
             <div id="active-jobs-badge" hx-get="/ui/jobs/count?filter=active" hx-push-url="false"
-              hx-trigger="load, every 1s, refreshActiveJobsBadge from:body" hx-target="#active-jobs-count"
+              hx-trigger="load, every 5s, refreshActiveJobsBadge from:body" hx-target="#active-jobs-count"
               hx-swap="innerHTML">
               <span id="active-jobs-count"
                 class="self-center text-sm font-semibold whitespace-nowrap text-gray-800 dark:text-blue-300 dark:drop-shadow-[0_0_10px_rgba(59,130,246,0.8)]"></span>

--- a/views/tag/edit_form.html
+++ b/views/tag/edit_form.html
@@ -116,7 +116,7 @@
 
         <!-- Audio Player -->
         <div class="flex items-center gap-2">
-          <a href="/stream/library/{{.Track.ID}}" download
+          <a href="/stream/library/{{.Track.ID}}" download="{{.Track.Path}}"
              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
             <i class="fas fa-download fa-xs"></i> Download
           </a>

--- a/views/tag/edit_form.html
+++ b/views/tag/edit_form.html
@@ -116,7 +116,7 @@
 
         <!-- Audio Player -->
         <div class="flex items-center gap-2">
-          <a href="/stream/library/{{.Track.ID}}" download="{{pathBase .Track.Path}}"
+          <a href="/stream?path={{urlEncode .Track.Path}}" download="{{pathBase .Track.Path}}"
              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
             <i class="fas fa-download fa-xs"></i> Download
           </a>
@@ -129,7 +129,7 @@
                    class="flex-1 h-1 mx-1 accent-gray-500 cursor-pointer"
                    oninput="seekAudioProgress(this)">
             <span class="time-display text-xs text-gray-500 dark:text-gray-400 w-8 text-right tabular-nums">0:00</span>
-            <audio src="/stream/library/{{.Track.ID}}" preload="none"
+            <audio src="/stream?path={{urlEncode .Track.Path}}" preload="none"
                    ontimeupdate="updateAudioProgress(this)"
                    onended="resetAudioPlayer(this)"></audio>
           </div>

--- a/views/tag/edit_form.html
+++ b/views/tag/edit_form.html
@@ -116,7 +116,7 @@
 
         <!-- Audio Player -->
         <div class="flex items-center gap-2">
-          <a href="/stream/library/{{.Track.ID}}" download="{{.Track.Path}}"
+          <a href="/stream/library/{{.Track.ID}}" download="{{pathBase .Track.Path}}"
              class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
             <i class="fas fa-download fa-xs"></i> Download
           </a>

--- a/views/tag/edit_form.html
+++ b/views/tag/edit_form.html
@@ -114,6 +114,27 @@
           </div>
         </div>
 
+        <!-- Audio Player -->
+        <div class="flex items-center gap-2">
+          <a href="/stream/library/{{.Track.ID}}" download
+             class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors">
+            <i class="fas fa-download fa-xs"></i> Download
+          </a>
+          <div class="audio-player flex items-center gap-2 flex-1">
+            <button type="button" class="play-btn flex-shrink-0 w-7 h-7 rounded-full bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 flex items-center justify-center transition-colors"
+                    onclick="toggleAudioPlayer(this)">
+              <i class="fas fa-play fa-xs text-gray-700 dark:text-gray-200"></i>
+            </button>
+            <input type="range" min="0" max="100" value="0" step="0.1"
+                   class="flex-1 h-1 mx-1 accent-gray-500 cursor-pointer"
+                   oninput="seekAudioProgress(this)">
+            <span class="time-display text-xs text-gray-500 dark:text-gray-400 w-8 text-right tabular-nums">0:00</span>
+            <audio src="/stream/library/{{.Track.ID}}" preload="none"
+                   ontimeupdate="updateAudioProgress(this)"
+                   onended="resetAudioPlayer(this)"></audio>
+          </div>
+        </div>
+
        <!-- Metadata -->
        <div class="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-6 gap-4">
          <div class="space-y-1">


### PR DESCRIPTION
> [!NOTE]
> This PR introduces a streaming feature. This feature intends not to turn Soulsolid into a player but to help during the tasks as figuring out if a song is the same as the other for duplicates queue items or playing a song when being preview/edited.


  - Adds a new streaming feature that serves audio files over HTTP (/stream/queue/:id, /stream/library/:id), with path traversal guards
  validating files stay within their allowed directories
  - Adds inline audio players to duplicate queue items (individual, grouped-by-album, grouped-by-artist views) so you can listen to both the new
   (download folder) and existing (library) file before deciding to replace or skip
  - Adds an always-visible audio player and download button to the track tag edit form
  - Slows down badge polling (every 1s → every 15s for import/lyrics queues, every 5s for active jobs) since HTMX events already update badges
  immediately on user action

  
<img width="929" height="995" alt="image" src="https://github.com/user-attachments/assets/ab30cf13-2494-4518-b161-b4280cc62b7e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio streaming and preview across import queue, grouped views, tag editor, and library track panel.
  * Play/pause, seek, progress display, and reset controls for inline audio players.

* **Performance**
  * Reduced HTMX polling frequency for queue and job badges (15s and 5s instead of 1s).

* **UI/UX**
  * Import queue badge shows count only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->