### PR TITLE
Feat/missing metadata

### DIFF
--- a/FEATURE_SPEC_KIT.md
+++ b/FEATURE_SPEC_KIT.md
@@ -436,9 +436,9 @@ For items requiring a user decision, integrate with the queue system:
 | QueueItemType | Value | Purpose | Used By |
 |---------------|-------|---------|---------|
 | `ManualReview` | `"manual_review"` | Track needs manual review before import | importing |
+| `MissingMetadata` | `"missing_metadata"` | Track is missing a required metadata field not permitted by `allow_missing_metadata` | importing |
 | `Duplicate` | `"duplicate"` | Track is a duplicate of existing track | importing |
 | `FailedImport` | `"failed_import"` | Track failed to import | importing |
-| `MissingMetadata` | `"missing_metadata"` | Track is missing required metadata | importing |
 | `ExistingLyrics` | `"existing_lyrics"` | Track already has lyrics | lyrics |
 | `Lyric404` | `"lyric_404"` | Lyrics not found (404) | lyrics |
 | `FailedLyrics` | `"failed_lyrics"` | Lyrics fetch failed due to error | lyrics |
@@ -468,7 +468,7 @@ Job runs (background)
 ```go
 item := music.QueueItem{
     ID:        track.ID,
-    Type:      music.Duplicate,
+    Types:     []music.QueueItemType{music.Duplicate, music.MissingMetadata}, // one item can carry several
     Track:     track,
     Timestamp: time.Now(),
     JobID:     jobID,
@@ -476,6 +476,10 @@ item := music.QueueItem{
 }
 return s.queue.Add(item)
 ```
+
+`QueueItem.Types` is a list: a single item may carry several types at once (e.g. `Duplicate` +
+`MissingMetadata`). Use `item.HasType(t)` to test for a type, or `item.PrimaryType()` when an
+item only ever has one (e.g. the lyrics queue).
 
 Only add when user decision is required — not for retriable failures or normal processing.
 
@@ -489,7 +493,7 @@ func (s *Service) ProcessQueueItem(ctx context.Context, itemID string, action st
     if err != nil {
         return fmt.Errorf("queue item not found: %w", err)
     }
-    switch item.Type {
+    switch item.PrimaryType() {
     case music.ExistingLyrics:
         switch action {
         case "override":

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -39,7 +39,12 @@ import:
   move: false # If false tracks will be kepts in the folder where you are importing them from and copied from it to your 'libraryPath:'
   always_queue: false # When true, it will queue every single imported track for manual review.
   duplicates: queue # queue | skip | replace
-  allow_missing_metadata: false # When true, allows importing tracks without artist or album metadata
+  allow_missing_metadata: # Per-field: when true the missing value is filled with a fallback default on import, otherwise the track is sent to the manual review queue
+    artist: false
+    album: false
+    title: false
+    year: false
+    genre: false
   paths:
     compilations: '%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
     album:soundtrack: '%asciify{$albumartist}/%asciify{$album} [OST] (%if{$original_year,$original_year,$year})/%asciify{$track $title}'

--- a/docs/importing.md
+++ b/docs/importing.md
@@ -19,7 +19,12 @@ import:
   move: false           # if false, files are copied; if true, originals are removed after import
   always_queue: false   # queue every track for manual review, even non-duplicates
   duplicates: queue     # queue | skip | replace
-  allow_missing_metadata: false  # allow importing tracks with no artist/album metadata
+  allow_missing_metadata:        # per-field control over importing tracks with missing metadata
+    artist: false                # when true, a missing field is filled with a fallback default on import;
+    album: false                 # when false, a track missing that field is sent to the missing_metadata queue
+    title: false
+    year: false
+    genre: false
   auto_start_watcher: false      # automatically watch the download path on startup
   paths:
     compilations: '%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}'
@@ -141,12 +146,22 @@ The import queue provides manual review capabilities for tracks that require use
 
 ### Queue Types
 
+A queue item can carry **more than one type at once** (e.g. a track that is both a `duplicate`
+and `missing_metadata`). Each applicable type is shown as its own badge, and the available
+actions are the combination of what each type allows.
+
 | Type | Trigger | Available Actions |
 |------|---------|-------------------|
-| `manual_review` | `always_queue: true` or first-time imports pending approval | `import`, `cancel` |
-| `duplicate` | Track with matching fingerprint already exists in library | `replace`, `cancel` |
-| `missing_metadata` | Track has no artist or album metadata and `allow_missing_metadata: false` | `import`, `cancel`, `delete` |
+| `manual_review` | `always_queue: true` or first-time imports pending approval | `import`, `cancel`, `delete` |
+| `missing_metadata` | Track is missing a required metadata field whose `allow_missing_metadata.<field>` is `false` | `cancel`, `delete` |
+| `duplicate` | Track with matching fingerprint already exists in library | `replace`, `cancel`, `delete` |
 | `failed_import` | Import attempt errored (e.g. file unreadable) | `cancel`, `delete` |
+
+**Missing metadata blocks the library.** While an item carries `missing_metadata`, the
+`import` and `replace` actions are disabled (only `cancel`/skip and `delete` remain) so an
+incomplete track can never enter or overwrite the library. This is enforced both in the UI and
+on the server. For example, a `duplicate` + `missing_metadata` item offers only skip/delete
+until the metadata is fixed.
 
 ### Telegram Integration
 

--- a/src/features/config/config.go
+++ b/src/features/config/config.go
@@ -27,12 +27,23 @@ type WebhookConfig struct {
 }
 
 type Import struct {
-	Move                 bool   `yaml:"move"` // If not copies
-	AlwaysQueue          bool   `yaml:"always_queue"`
-	Duplicates           string `yaml:"duplicates"` // "replace", "skip", "queue"
-	PathOptions          Paths  `yaml:"paths"`
-	AutoStartWatcher     bool   `yaml:"auto_start_watcher"`
-	AllowMissingMetadata bool   `yaml:"allow_missing_metadata"`
+	Move                 bool                 `yaml:"move"` // If not copies
+	AlwaysQueue          bool                 `yaml:"always_queue"`
+	Duplicates           string               `yaml:"duplicates"` // "replace", "skip", "queue"
+	PathOptions          Paths                `yaml:"paths"`
+	AutoStartWatcher     bool                 `yaml:"auto_start_watcher"`
+	AllowMissingMetadata AllowMissingMetadata `yaml:"allow_missing_metadata"`
+}
+
+// AllowMissingMetadata controls, per field, whether tracks missing that metadata field may
+// still be imported. When a field is allowed, a fallback default is filled in on import;
+// when it is not allowed, a track missing that field is sent to the manual review queue.
+type AllowMissingMetadata struct {
+	Artist bool `yaml:"artist"`
+	Album  bool `yaml:"album"`
+	Title  bool `yaml:"title"`
+	Year   bool `yaml:"year"`
+	Genre  bool `yaml:"genre"`
 }
 
 type Paths struct {

--- a/src/features/config/default.go
+++ b/src/features/config/default.go
@@ -37,6 +37,13 @@ var defaultConfig = Config{
 		AlwaysQueue:      false,
 		Duplicates:       "queue",
 		AutoStartWatcher: false,
+		AllowMissingMetadata: AllowMissingMetadata{
+			Artist: false,
+			Album:  false,
+			Title:  false,
+			Year:   true,
+			Genre:  true,
+		},
 		PathOptions: Paths{
 			Compilations:    "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} (%if{$original_year,$original_year,$year})/%asciify{$track $title}",
 			AlbumSoundtrack: "%asciify{$genre}/%asciify{$format}/%asciify{$albumartist}/%asciify{$album} [OST] (%if{$original_year,$original_year,$year})/%asciify{$track $title}",

--- a/src/features/config/handlers.go
+++ b/src/features/config/handlers.go
@@ -41,11 +41,17 @@ func (h *Handler) UpdateSettings(c *fiber.Ctx) error {
 		DownloadPath: c.FormValue("downloadPath"),
 		Database:     currentConfig.Database, // Preserve database settings
 		Import: Import{
-			AutoStartWatcher:     currentConfig.Import.AutoStartWatcher,
-			Move:                 c.FormValue("import.move") == "true",
-			AlwaysQueue:          c.FormValue("import.always_queue") == "true",
-			Duplicates:           c.FormValue("import.duplicates"),
-			AllowMissingMetadata: c.FormValue("import.allow_missing_metadata") == "true",
+			AutoStartWatcher: currentConfig.Import.AutoStartWatcher,
+			Move:             c.FormValue("import.move") == "true",
+			AlwaysQueue:      c.FormValue("import.always_queue") == "true",
+			Duplicates:       c.FormValue("import.duplicates"),
+			AllowMissingMetadata: AllowMissingMetadata{
+				Artist: c.FormValue("import.allow_missing_metadata.artist") == "true",
+				Album:  c.FormValue("import.allow_missing_metadata.album") == "true",
+				Title:  c.FormValue("import.allow_missing_metadata.title") == "true",
+				Year:   c.FormValue("import.allow_missing_metadata.year") == "true",
+				Genre:  c.FormValue("import.allow_missing_metadata.genre") == "true",
+			},
 			PathOptions: Paths{
 				DefaultPath:     c.FormValue("import.paths.default_path"),
 				Compilations:    c.FormValue("import.paths.compilations"),

--- a/src/features/downloading/download_job.go
+++ b/src/features/downloading/download_job.go
@@ -121,16 +121,8 @@ func (e *DownloadJobTask) executeTrackDownload(ctx context.Context, job *music.J
 
 	progressUpdater(75, "Track downloaded, processing metadata...")
 
-	// Enhance track metadata with fallbacks
-	slog.Debug("Enhancing track metadata with fallbacks", "trackID", track.ID)
-	track.EnsureMetadataDefaults()
-
-	// Validate required metadata
-	slog.Debug("Validating required metadata", "trackID", track.ID)
-	if err := track.ValidateRequiredMetadata(); err != nil {
-		slog.Error("Metadata validation failed", "trackID", track.ID, "error", err)
-		return nil, fmt.Errorf("metadata validation failed: %w", err)
-	}
+	// Downloads keep the source metadata as-is; missing fields are left empty.
+	// Filling fallback defaults only happens when importing into the library.
 
 	filePath := track.Path
 	// Tag the file
@@ -217,14 +209,9 @@ func (e *DownloadJobTask) executeAlbumDownload(ctx context.Context, job *music.J
 		progressUpdater(progress, fmt.Sprintf("Processing track %d/%d: %s...", i+1, totalTracks, track.Title))
 		slog.Debug("Processing album track", "albumID", albumID, "trackID", track.ID, "trackNumber", i+1, "title", track.Title)
 
-		// Track is already downloaded by plugin, just validate and tag
+		// Track is already downloaded by plugin, just tag it. Downloads keep the source
+		// metadata as-is; missing-field defaulting only applies when importing.
 		slog.Debug("Processing album track metadata", "trackID", track.ID, "hasAlbum", track.Album != nil, "hasArtwork", track.Album != nil && len(track.Album.ArtworkData) > 0)
-		// Enhance and validate metadata
-		track.EnsureMetadataDefaults()
-		if err := track.ValidateRequiredMetadata(); err != nil {
-			slog.Error("Album track metadata validation failed", "trackID", track.ID, "error", err)
-			return nil, fmt.Errorf("album track metadata validation failed: %w", err)
-		}
 
 		// Tag the file (artwork is already downloaded by plugin and set in track.Album.ArtworkData)
 		filePath := track.Path
@@ -337,12 +324,8 @@ func (e *DownloadJobTask) executeArtistDownload(ctx context.Context, job *music.
 		// Track is already downloaded by plugin, just validate and tag
 		slog.Debug("Processing artist track metadata", "trackID", track.ID, "hasAlbum", track.Album != nil, "hasArtwork", track.Album != nil && len(track.Album.ArtworkData) > 0)
 
-		// Enhance and validate metadata
-		track.EnsureMetadataDefaults()
-		if err := track.ValidateRequiredMetadata(); err != nil {
-			slog.Error("Artist track metadata validation failed", "trackID", track.ID, "error", err)
-			return nil, fmt.Errorf("artist track metadata validation failed: %w", err)
-		}
+		// Downloads keep the source metadata as-is; missing-field defaulting only applies
+		// when importing.
 
 		// Tag the file
 		filePath := track.Path
@@ -451,12 +434,8 @@ func (e *DownloadJobTask) executeTracksDownload(ctx context.Context, job *music.
 			continue // Skip this track but continue with others
 		}
 
-		// Process the downloaded track
-		track.EnsureMetadataDefaults()
-		if err := track.ValidateRequiredMetadata(); err != nil {
-			slog.Error("Track metadata validation failed", "trackID", trackID, "error", err)
-			return nil, fmt.Errorf("track metadata validation failed: %w", err)
-		}
+		// Process the downloaded track. Downloads keep the source metadata as-is; missing-field
+		// defaulting only applies when importing.
 
 		filePath := track.Path
 		slog.Debug("Tagging track file", "trackID", trackID, "filePath", filePath, "title", track.Title)
@@ -550,12 +529,8 @@ func (e *DownloadJobTask) executePlaylistDownload(ctx context.Context, job *musi
 			continue // Skip this track but continue with others
 		}
 
-		// Process the downloaded track
-		track.EnsureMetadataDefaults()
-		if err := track.ValidateRequiredMetadata(); err != nil {
-			slog.Error("Track metadata validation failed", "trackID", trackID, "error", err)
-			return nil, fmt.Errorf("track metadata validation failed: %w", err)
-		}
+		// Process the downloaded track. Downloads keep the source metadata as-is; missing-field
+		// defaulting only applies when importing.
 
 		filePath := track.Path
 		slog.Debug("Tagging playlist track file", "trackID", trackID, "filePath", filePath, "title", track.Title)

--- a/src/features/importing/directory_job.go
+++ b/src/features/importing/directory_job.go
@@ -99,42 +99,60 @@ func countSupportedFiles(pathToImport string) int {
 	return totalFiles
 }
 
-// determineAction determines what action to take for a track based on config and duplicate tracks
-func determineAction(track *music.Track, duplicateTrack *music.Track, config config.Import, logger *slog.Logger) (ImportAction, music.QueueItemType, map[string]string) {
-	if err := track.ValidateRequiredMetadata(); err != nil {
-		return QueueTrack, MissingMetadata, map[string]string{"error": err.Error()}
+// determineAction determines what action to take for a track based on config and duplicate
+// tracks. A queued track may carry more than one type at once (e.g. Duplicate + MissingMetadata).
+func determineAction(track *music.Track, duplicateTrack *music.Track, config config.Import, logger *slog.Logger) (ImportAction, []music.QueueItemType, map[string]string) {
+	metadata := map[string]string{}
+	var types []music.QueueItemType
+
+	// Permitted missing fields were already defaulted before duplicate detection; any field
+	// still missing here is not permitted by config, so flag the track as missing metadata.
+	amm := config.AllowMissingMetadata
+	missingErr := track.ValidateRequiredMetadata(amm.Artist, amm.Album, amm.Title, amm.Year, amm.Genre)
+	if missingErr != nil {
+		types = append(types, MissingMetadata)
+		metadata["error"] = missingErr.Error()
+	}
+
+	if duplicateTrack != nil {
+		// Fast paths apply only when force-queuing is off. "skip" discards the duplicate
+		// regardless of metadata (nothing enters the library). "replace" only auto-replaces a
+		// complete track; an incomplete one is queued instead so it can't silently overwrite
+		// the library with missing metadata.
+		if !config.AlwaysQueue {
+			switch config.Duplicates {
+			case "skip":
+				logger.Info("Service.runDirectoryImport: Decided to skip duplicate track", "reason", "skip enabled for duplicates", "duplicate_path", duplicateTrack.Path, "title", track.Title)
+				return SkipTrack, nil, nil
+			case "replace":
+				if missingErr == nil {
+					logger.Info("Service.runDirectoryImport: Decided to replace duplicate track", "reason", "replace enabled for duplicates", "duplicate_path", duplicateTrack.Path, "new_path", track.Path, "title", track.Title)
+					return ReplaceTrack, nil, nil
+				}
+				logger.Info("Service.runDirectoryImport: queuing duplicate instead of replacing", "reason", "missing required metadata", "duplicate_path", duplicateTrack.Path, "title", track.Title)
+			}
+		}
+		types = append(types, Duplicate)
+		metadata["duplicate_path"] = duplicateTrack.Path
+		logger.Info("Service.runDirectoryImport: Decided to queue as duplicate", "duplicate_path", duplicateTrack.Path, "title", track.Title, "types", types)
+		return QueueTrack, types, metadata
+	}
+
+	// No duplicate.
+	if missingErr != nil {
+		logger.Info("Service.runDirectoryImport: track queued as missing metadata", "title", track.Title, "error", missingErr.Error())
+		return QueueTrack, types, metadata
 	}
 	if config.AlwaysQueue {
-		if duplicateTrack != nil {
-			logger.Info("Service.runDirectoryImport: track queued for manual review", "reason", "always_queue enabled", "duplicate", "true", "title", track.Title, "duplicate_path", duplicateTrack.Path)
-			return QueueTrack, Duplicate, map[string]string{"duplicate_path": duplicateTrack.Path}
-		} else {
-			logger.Info("Service.runDirectoryImport: track queued for manual review", "reason", "always_queue enabled", "duplicate", "true", "title", track.Title)
-			return QueueTrack, ManualReview, nil
-		}
+		logger.Info("Service.runDirectoryImport: track queued for manual review", "reason", "always_queue enabled", "title", track.Title)
+		return QueueTrack, []music.QueueItemType{ManualReview}, nil
 	}
-	if duplicateTrack != nil {
-		switch config.Duplicates {
-		case "skip":
-			logger.Info("Service.runDirectoryImport: Decided to skip duplicate track", "reason", "skip enabled for duplicates", "duplicate", "true", "duplicate_path", duplicateTrack.Path, "title", track.Title)
-			return SkipTrack, "", nil
-		case "replace":
-			logger.Info("Service.runDirectoryImport: Decided to replace duplicate track", "reason", "replace enabled for duplicates", "duplicate", "true", "duplicate_path", duplicateTrack.Path, "new_path", track.Path, "title", track.Title)
-			return ReplaceTrack, "", nil
-		case "queue":
-			logger.Info("Service.runDirectoryImport: Decided to queue as duplicate", "reason", "queue enabled for duplicates", "duplicate", "true", "duplicate_path", duplicateTrack.Path, "title", track.Title)
-			return QueueTrack, Duplicate, map[string]string{"duplicate_path": duplicateTrack.Path}
-		default:
-			logger.Warn("Service.runDirectoryImport: Decided queued as duplicate", "reason", "unknown duplicates setting, defaulting to queue", "duplicate", "true", "duplicate_path", duplicateTrack.Path, "title", track.Title)
-			return QueueTrack, ManualReview, map[string]string{"error": duplicateTrack.Path}
-		}
-	}
-	logger.Info("Service.runDirectoryImport: Decided to import track", "reason", "track didn't exists in the library", "duplicate", "false", "title", track.Title, "artist", track.Artists)
-	return ImportTrack, "", nil
+	logger.Info("Service.runDirectoryImport: Decided to import track", "reason", "track didn't exists in the library", "title", track.Title, "artist", track.Artists)
+	return ImportTrack, nil, nil
 }
 
 // addTrackToQueue adds a track to the queue
-func (e *DirectoryImportTask) addTrackToQueue(track *music.Track, queueType music.QueueItemType, jobID string, duplicateTrack *music.Track, logger *slog.Logger, metadata map[string]string) error {
+func (e *DirectoryImportTask) addTrackToQueue(track *music.Track, queueTypes []music.QueueItemType, jobID string, duplicateTrack *music.Track, logger *slog.Logger, metadata map[string]string) error {
 	if track == nil {
 		return fmt.Errorf("track cannot be nil")
 	}
@@ -147,7 +165,7 @@ func (e *DirectoryImportTask) addTrackToQueue(track *music.Track, queueType musi
 
 	item := music.QueueItem{
 		ID:        track.ID,
-		Type:      queueType,
+		Types:     queueTypes,
 		Track:     track,
 		Timestamp: time.Now(),
 		JobID:     jobID,
@@ -248,18 +266,19 @@ func (e *DirectoryImportTask) runDirectoryImport(ctx context.Context, pathToImpo
 				nullTrackForQueue := music.Track{}
 				nullTrackForQueue.Title = path
 				nullTrackForQueue.Path = path
-				nullTrackForQueue.EnsureMetadataDefaults()
+				nullTrackForQueue.EnsureMetadataDefaults(true, true, true, true, true)
 				nullTrackForQueue.ID = generateTrackIDFromPath(path) // ID generate for queue duplicates.
-				if err := e.addTrackToQueue(&nullTrackForQueue, FailedImport, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
+				if err := e.addTrackToQueue(&nullTrackForQueue, []music.QueueItemType{FailedImport}, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
 					logger.Error("Service.runDirectoryImport: failed to add metadata-failed track to queue", "error", err)
 				}
 				processedFiles++
 				return nil
 			}
-			if config.AllowMissingMetadata {
-				trackToImport.EnsureMetadataDefaults()
-			}
 			slog.Info("Read metadata from file", "path", path, "track", trackToImport)
+
+			// Apply default metadata if configured to allow missing metadata
+			amm := config.AllowMissingMetadata
+			trackToImport.EnsureMetadataDefaults(amm.Artist, amm.Album, amm.Title, amm.Year, amm.Genre)
 
 			// Set source data for local file
 			trackToImport.MetadataSource = music.MetadataSource{
@@ -273,7 +292,7 @@ func (e *DirectoryImportTask) runDirectoryImport(ctx context.Context, pathToImpo
 				stats.Errors++
 				// Set track ID from path and add to queue for manual review
 				trackToImport.ID = generateTrackIDFromPath(path)
-				if err := e.addTrackToQueue(trackToImport, FailedImport, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
+				if err := e.addTrackToQueue(trackToImport, []music.QueueItemType{FailedImport}, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
 					logger.Error("Service.runDirectoryImport: failed to add fingerprint-failed track to queue", "error", err)
 				}
 				processedFiles++
@@ -288,23 +307,23 @@ func (e *DirectoryImportTask) runDirectoryImport(ctx context.Context, pathToImpo
 			if err != nil {
 				logger.Error("Service.runDirectoryImport: failed to find duplicate track", "error", err)
 				stats.Errors++
-				if err := e.addTrackToQueue(trackToImport, FailedImport, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
+				if err := e.addTrackToQueue(trackToImport, []music.QueueItemType{FailedImport}, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
 					logger.Error("Service.runDirectoryImport: failed to add database-error track to queue", "error", err)
 				}
 				processedFiles++
 				return nil
 			}
 			var action ImportAction
-			var queueType music.QueueItemType
+			var queueTypes []music.QueueItemType
 			var itemMetadata map[string]string
-			action, queueType, itemMetadata = determineAction(trackToImport, duplicateTrack, config, logger)
+			action, queueTypes, itemMetadata = determineAction(trackToImport, duplicateTrack, config, logger)
 
 			switch action {
 			case SkipTrack:
 				stats.Skipped++
 				logger.Info("Service.runDirectoryImport: Skipping duplicate track", "reason", "track already exists", "duplicate_path", path, "title", trackToImport.Title, "color", "blue")
 			case QueueTrack:
-				if err := e.addTrackToQueue(trackToImport, queueType, job.ID, duplicateTrack, logger, itemMetadata); err != nil {
+				if err := e.addTrackToQueue(trackToImport, queueTypes, job.ID, duplicateTrack, logger, itemMetadata); err != nil {
 					stats.Errors++
 				} else {
 					stats.Queued++
@@ -315,7 +334,7 @@ func (e *DirectoryImportTask) runDirectoryImport(ctx context.Context, pathToImpo
 					logger.Error("Service.runDirectoryImport: failed to replace track", "error", err)
 					stats.Errors++
 					// Add failed track to queue for manual review
-					if err := e.addTrackToQueue(trackToImport, FailedImport, job.ID, duplicateTrack, logger, map[string]string{"error": err.Error()}); err != nil {
+					if err := e.addTrackToQueue(trackToImport, []music.QueueItemType{FailedImport}, job.ID, duplicateTrack, logger, map[string]string{"error": err.Error()}); err != nil {
 						logger.Error("Service.runDirectoryImport: failed to add failed replace track to queue", "error", err)
 					}
 				} else {
@@ -323,20 +342,13 @@ func (e *DirectoryImportTask) runDirectoryImport(ctx context.Context, pathToImpo
 					logger.Info("Service.runDirectoryImport: duplicate track replaced", "title", trackToImport.Title, "color", "orange")
 				}
 			case ImportTrack:
-				// Apply default metadata if configured to allow missing metadata
-				if err := trackToImport.ValidateRequiredMetadata(); err != nil {
-					logger.Error("Service.runDirectoryImport: failed to validate required metadata", "error", err, "title", trackToImport.Title, "path", trackToImport.Path)
-					stats.Errors++
-					// Add failed track to queue for manual review
-					if err := e.addTrackToQueue(trackToImport, FailedImport, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
-						logger.Error("Service.runDirectoryImport: failed to add failed import track to queue", "error", err)
-					}
-				}
+				// determineAction already validated required metadata and applied any
+				// permitted fallback defaults, so the track is ready to import here.
 				if err := e.service.importTrack(ctx, trackToImport, moveFiles, logger); err != nil {
 					logger.Error("Service.runDirectoryImport: failed to import track", "error", err, "title", trackToImport.Title, "path", trackToImport.Path)
 					stats.Errors++
 					// Add failed track to queue for manual review
-					if err := e.addTrackToQueue(trackToImport, FailedImport, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
+					if err := e.addTrackToQueue(trackToImport, []music.QueueItemType{FailedImport}, job.ID, nil, logger, map[string]string{"error": err.Error()}); err != nil {
 						logger.Error("Service.runDirectoryImport: failed to add failed import track to queue", "error", err)
 					}
 				} else {

--- a/src/features/importing/handlers.go
+++ b/src/features/importing/handlers.go
@@ -18,14 +18,28 @@ type Handler struct {
 	service *Service
 }
 
-// queueItemView is a view model for queue items that includes the track
+// queueItemView is a view model for queue items that includes the track. A single item can
+// carry several statuses at once, so the booleans below are not mutually exclusive.
 type queueItemView struct {
 	ID           string
-	Type         string
 	Timestamp    time.Time
 	JobID        string
 	Track        *music.Track
 	ItemMetadata map[string]string
+
+	// Status flags (derived from the item's types; may be true in combination)
+	IsDuplicate       bool
+	IsMissingMetadata bool
+	IsFailedImport    bool
+	IsManualReview    bool
+
+	// Action availability, implementing the "block until metadata is fixed" rule
+	ShowReplace    bool
+	ReplaceEnabled bool
+	ShowImport     bool
+	ImportEnabled  bool
+	CancelLabel    string // "Skip" for duplicates/failed imports, otherwise "Cancel"
+	BlockReason    string // tooltip shown on disabled import/replace buttons
 }
 
 // groupView is a view model for grouped queue items
@@ -40,14 +54,41 @@ func convertQueueItem(item music.QueueItem) (queueItemView, error) {
 	if item.Track == nil {
 		return queueItemView{}, errors.New("queue item has no track")
 	}
-	return queueItemView{
-		ID:           item.ID,
-		Type:         string(item.Type),
-		Timestamp:    item.Timestamp,
-		JobID:        item.JobID,
-		Track:        item.Track,
-		ItemMetadata: item.Metadata,
-	}, nil
+	isDup := item.HasType(music.Duplicate)
+	isMissing := item.HasType(music.MissingMetadata)
+	isFailed := item.HasType(music.FailedImport)
+	isManual := item.HasType(music.ManualReview)
+
+	view := queueItemView{
+		ID:                item.ID,
+		Timestamp:         item.Timestamp,
+		JobID:             item.JobID,
+		Track:             item.Track,
+		ItemMetadata:      item.Metadata,
+		IsDuplicate:       isDup,
+		IsMissingMetadata: isMissing,
+		IsFailedImport:    isFailed,
+		IsManualReview:    isManual,
+	}
+
+	// Replace is a duplicate-only action; it is blocked while metadata is missing or the
+	// import failed, so the library is never overwritten with an incomplete track.
+	view.ShowReplace = isDup
+	view.ReplaceEnabled = isDup && !isMissing && !isFailed
+
+	// Import applies to manual-review / missing-metadata items (never duplicates or failed
+	// imports). It stays disabled until the missing required metadata is fixed.
+	view.ShowImport = !isDup && !isFailed && (isManual || isMissing)
+	view.ImportEnabled = view.ShowImport && !isMissing
+
+	view.CancelLabel = "Cancel"
+	if isDup || isFailed {
+		view.CancelLabel = "Skip"
+	}
+	if isMissing {
+		view.BlockReason = "Fix the missing metadata before importing"
+	}
+	return view, nil
 }
 
 // NewHandler creates a new handler for the organizing feature.
@@ -321,9 +362,10 @@ func (h *Handler) RenderGroupedQueueItems(c *fiber.Ctx) error {
 				continue
 			}
 			viewItems = append(viewItems, view)
-			if view.Type == "duplicate" {
+			if view.IsDuplicate {
 				hasDuplicates = true
-			} else if view.Type != "failed_import" && view.Type != "missing_metadata" {
+			}
+			if view.ImportEnabled {
 				hasImportable = true
 			}
 		}

--- a/src/features/importing/queue.go
+++ b/src/features/importing/queue.go
@@ -6,7 +6,7 @@ import "github.com/contre95/soulsolid/src/music"
 
 const (
 	ManualReview    music.QueueItemType = "manual_review"
+	MissingMetadata music.QueueItemType = "missing_metadata"
 	Duplicate       music.QueueItemType = "duplicate"
 	FailedImport    music.QueueItemType = "failed_import"
-	MissingMetadata music.QueueItemType = "missing_metadata"
 )

--- a/src/features/importing/service.go
+++ b/src/features/importing/service.go
@@ -215,8 +215,13 @@ func (s *Service) ProcessQueueItem(ctx context.Context, itemID string, action st
 		return fmt.Errorf("queue item does not contain a valid track")
 	}
 	// Validate action based on item type
-	if item.Type == FailedImport && (action == "import" || action == "replace") {
+	if item.HasType(FailedImport) && (action == "import" || action == "replace") {
 		return fmt.Errorf("action '%s' not allowed for failed import items (only skip/cancel and delete)", action)
+	}
+	// A track missing required metadata is blocked from entering the library until the
+	// metadata is fixed, so import/replace are not allowed while that condition holds.
+	if item.HasType(MissingMetadata) && (action == "import" || action == "replace") {
+		return fmt.Errorf("action '%s' not allowed: track is missing required metadata", action)
 	}
 	track := item.Track
 	switch action {
@@ -290,10 +295,10 @@ func (s *Service) ProcessQueueGroup(ctx context.Context, groupKey string, groupT
 	// Process each item in the group, filtering by type based on action
 	for _, item := range groupItems {
 		// "import" skips duplicates (use "replace" for those); "replace" only processes duplicates
-		if action == "import" && item.Type == music.Duplicate {
+		if action == "import" && item.HasType(music.Duplicate) {
 			continue
 		}
-		if action == "replace" && item.Type != music.Duplicate {
+		if action == "replace" && !item.HasType(music.Duplicate) {
 			continue
 		}
 		if err := s.ProcessQueueItem(ctx, item.ID, action); err != nil {
@@ -326,10 +331,9 @@ func (s *Service) replaceTrack(ctx context.Context, newTrack, existingTrack *mus
 	existingTrack.Metadata = newTrack.Metadata
 	existingTrack.Title = newTrack.Title
 	existingTrack.TitleVersion = newTrack.TitleVersion
-	// Apply default metadata if configured to allow missing metadata
-	if s.config.Get().Import.AllowMissingMetadata {
-		existingTrack.EnsureMetadataDefaults()
-	}
+	// Fill any permitted missing metadata fields with fallback defaults
+	amm := s.config.Get().Import.AllowMissingMetadata
+	existingTrack.EnsureMetadataDefaults(amm.Artist, amm.Album, amm.Title, amm.Year, amm.Genre)
 	if err := s.populateTrackArtistsAndAlbum(ctx, newTrack, logger); err != nil {
 		return err
 	}
@@ -422,10 +426,9 @@ func (s *Service) importTrack(ctx context.Context, track *music.Track, move bool
 		return err
 	}
 
-	// Apply default metadata if configured to allow missing metadata
-	if s.config.Get().Import.AllowMissingMetadata {
-		track.EnsureMetadataDefaults()
-	}
+	// Fill any permitted missing metadata fields with fallback defaults
+	amm := s.config.Get().Import.AllowMissingMetadata
+	track.EnsureMetadataDefaults(amm.Artist, amm.Album, amm.Title, amm.Year, amm.Genre)
 
 	if err := track.Validate(); err != nil {
 		logger.Error("Service.importTrack: track validation failed after population", "error", err, "title", track.Title)

--- a/src/features/importing/telegram.go
+++ b/src/features/importing/telegram.go
@@ -289,12 +289,7 @@ func (h *TelegramHandler) formatQueueItemMessage(item music.QueueItem, totalCoun
 		}
 	}
 
-	typeText := "Manual Review"
-	if item.Type == Duplicate {
-		typeText = "Duplicate"
-	} else if item.Type == FailedImport {
-		typeText = "Failed Import"
-	}
+	typeText := queueTypeLabel(item)
 
 	// Escape text fields for Markdown, but use code formatting for file path
 	escapedTitle := h.escapeMarkdown(track.Title)
@@ -350,27 +345,60 @@ func (h *TelegramHandler) escapeMarkdown(text string) string {
 }
 
 // createInlineKeyboard creates appropriate buttons based on item type
+// queueTypeLabel builds a human-readable label listing every type an item carries,
+// e.g. "Duplicate, Missing Metadata".
+func queueTypeLabel(item music.QueueItem) string {
+	var parts []string
+	if item.HasType(Duplicate) {
+		parts = append(parts, "Duplicate")
+	}
+	if item.HasType(MissingMetadata) {
+		parts = append(parts, "Missing Metadata")
+	}
+	if item.HasType(FailedImport) {
+		parts = append(parts, "Failed Import")
+	}
+	if item.HasType(ManualReview) {
+		parts = append(parts, "Manual Review")
+	}
+	if len(parts) == 0 {
+		return "Manual Review"
+	}
+	return strings.Join(parts, ", ")
+}
+
 func (h *TelegramHandler) createInlineKeyboard(item music.QueueItem) tgbotapi.InlineKeyboardMarkup {
 	var buttons [][]tgbotapi.InlineKeyboardButton
 
-	// Action buttons based on type
-	if item.Type == Duplicate {
+	// Action buttons based on type. A track missing required metadata is blocked from
+	// import/replace until the metadata is fixed (only skip/cancel and delete remain).
+	blocked := item.HasType(MissingMetadata)
+	switch {
+	case item.HasType(Duplicate):
+		row := []tgbotapi.InlineKeyboardButton{}
+		if !blocked {
+			row = append(row, tgbotapi.NewInlineKeyboardButtonData("✴️ Replace", fmt.Sprintf("queue_replace_%s", item.ID)))
+		}
+		row = append(row,
+			tgbotapi.NewInlineKeyboardButtonData("⏭️ Skip", fmt.Sprintf("queue_cancel_%s", item.ID)),
+			tgbotapi.NewInlineKeyboardButtonData("🗑️ Delete", fmt.Sprintf("queue_delete_%s", item.ID)),
+		)
+		buttons = append(buttons, row)
+	case item.HasType(FailedImport):
 		buttons = append(buttons, []tgbotapi.InlineKeyboardButton{
-			tgbotapi.NewInlineKeyboardButtonData("✴️ Replace", fmt.Sprintf("queue_replace_%s", item.ID)),
 			tgbotapi.NewInlineKeyboardButtonData("⏭️ Skip", fmt.Sprintf("queue_cancel_%s", item.ID)),
 			tgbotapi.NewInlineKeyboardButtonData("🗑️ Delete", fmt.Sprintf("queue_delete_%s", item.ID)),
 		})
-	} else if item.Type == FailedImport {
-		buttons = append(buttons, []tgbotapi.InlineKeyboardButton{
-			tgbotapi.NewInlineKeyboardButtonData("⏭️ Skip", fmt.Sprintf("queue_cancel_%s", item.ID)),
-			tgbotapi.NewInlineKeyboardButtonData("🗑️ Delete", fmt.Sprintf("queue_delete_%s", item.ID)),
-		})
-	} else {
-		buttons = append(buttons, []tgbotapi.InlineKeyboardButton{
-			tgbotapi.NewInlineKeyboardButtonData("✅ Import", fmt.Sprintf("queue_import_%s", item.ID)),
+	default:
+		row := []tgbotapi.InlineKeyboardButton{}
+		if !blocked {
+			row = append(row, tgbotapi.NewInlineKeyboardButtonData("✅ Import", fmt.Sprintf("queue_import_%s", item.ID)))
+		}
+		row = append(row,
 			tgbotapi.NewInlineKeyboardButtonData("❌ Cancel", fmt.Sprintf("queue_cancel_%s", item.ID)),
 			tgbotapi.NewInlineKeyboardButtonData("🗑️ Delete", fmt.Sprintf("queue_delete_%s", item.ID)),
-		})
+		)
+		buttons = append(buttons, row)
 	}
 
 	// Navigation buttons

--- a/src/features/lyrics/handlers.go
+++ b/src/features/lyrics/handlers.go
@@ -54,12 +54,12 @@ type groupView struct {
 // convertQueueItem converts a music.QueueItem to queueItemView
 func convertQueueItem(item music.QueueItem) (queueItemView, error) {
 	if item.Track == nil {
-		slog.Error("Queue item has no track", "itemID", item.ID, "type", item.Type)
+		slog.Error("Queue item has no track", "itemID", item.ID, "type", item.PrimaryType())
 		return queueItemView{}, errors.New("queue item has no track")
 	}
 	return queueItemView{
 		ID:           item.ID,
-		Type:         string(item.Type),
+		Type:         string(item.PrimaryType()),
 		Timestamp:    item.Timestamp,
 		Track:        item.Track,
 		ItemMetadata: item.Metadata,

--- a/src/features/lyrics/lyrics_job.go
+++ b/src/features/lyrics/lyrics_job.go
@@ -175,7 +175,7 @@ func (t *LyricsJobTask) Execute(ctx context.Context, job *music.Job, progressUpd
 
 	for id, item := range finalQueueItems {
 		if !initialQueueIDs[id] {
-			switch item.Type {
+			switch item.PrimaryType() {
 			case ExistingLyrics:
 				existingLyricsQueued++
 				job.Logger.Info("New existing_lyrics queue item added", "trackID", id, "color", "cyan")

--- a/src/features/lyrics/service.go
+++ b/src/features/lyrics/service.go
@@ -197,7 +197,7 @@ func (s *Service) AddLyricsQueueItem(track *music.Track, qType music.QueueItemTy
 	}
 	item := music.QueueItem{
 		ID:        track.ID,
-		Type:      qType,
+		Types:     []music.QueueItemType{qType},
 		Track:     track,
 		Timestamp: time.Now(),
 		Metadata:  metadata,
@@ -221,7 +221,7 @@ func (s *Service) ProcessLyricsQueueItem(ctx context.Context, itemID string, act
 	}
 
 	track := item.Track
-	switch item.Type {
+	switch item.PrimaryType() {
 	case ExistingLyrics:
 		switch action {
 		case "override":
@@ -295,7 +295,7 @@ func (s *Service) ProcessLyricsQueueItem(ctx context.Context, itemID string, act
 			return fmt.Errorf("invalid action '%s' for failed_lyrics, expected 'skip', 'edit_manual', or 'no_lyrics'", action)
 		}
 	default:
-		return fmt.Errorf("unsupported queue item type: %s", item.Type)
+		return fmt.Errorf("unsupported queue item type: %s", item.PrimaryType())
 	}
 }
 

--- a/src/infra/tag/tag_writer.go
+++ b/src/infra/tag/tag_writer.go
@@ -108,34 +108,47 @@ func (t *TagWriter) tagMP3(filePath string, track *music.Track) error {
 		tag.SetAlbum(track.Album.Title)
 	}
 
-	tag.SetGenre(track.Metadata.Genre)
+	// Genre - set, or remove the frame entirely when cleared
+	tag.DeleteFrames(tag.CommonID("Genre"))
+	if track.Metadata.Genre != "" {
+		tag.SetGenre(track.Metadata.Genre)
+	}
 
-	// Year - always set, replacing existing
+	// Year - set, or remove the frame entirely when cleared. Delete every
+	// year frame variant (v2.2/v2.3/v2.4) so a stale one can't resurface.
+	tag.DeleteFrames("TYER")
+	tag.DeleteFrames("TDRC")
+	tag.DeleteFrames("TDAT")
 	if track.Metadata.Year > 0 {
 		tag.SetYear(strconv.Itoa(track.Metadata.Year))
 	}
 
-	// ISRC
+	// ISRC - delete existing first so a cleared value removes the frame
+	tag.DeleteFrames("TSRC")
 	if track.ISRC != "" {
 		tag.AddTextFrame("TSRC", id3v2.EncodingUTF8, track.ISRC)
 	}
 
 	// Track number
+	tag.DeleteFrames("TRCK")
 	if track.Metadata.TrackNumber > 0 {
 		tag.AddTextFrame("TRCK", id3v2.EncodingUTF8, strconv.Itoa(track.Metadata.TrackNumber))
 	}
 
 	// Disc number
+	tag.DeleteFrames("TPOS")
 	if track.Metadata.DiscNumber > 0 {
 		tag.AddTextFrame("TPOS", id3v2.EncodingUTF8, strconv.Itoa(track.Metadata.DiscNumber))
 	}
 
 	// Composer
+	tag.DeleteFrames("TCOM")
 	if track.Metadata.Composer != "" {
 		tag.AddTextFrame("TCOM", id3v2.EncodingUTF8, track.Metadata.Composer)
 	}
 
 	// BPM
+	tag.DeleteFrames("TBPM")
 	if track.Metadata.BPM > 0 {
 		tag.AddTextFrame("TBPM", id3v2.EncodingUTF8, fmt.Sprintf("%.0f", track.Metadata.BPM))
 	}
@@ -153,6 +166,7 @@ func (t *TagWriter) tagMP3(filePath string, track *music.Track) error {
 	}
 
 	// Title version (subtitle)
+	tag.DeleteFrames("TIT3")
 	if track.TitleVersion != "" {
 		tag.AddTextFrame("TIT3", id3v2.EncodingUTF8, track.TitleVersion)
 	}
@@ -304,34 +318,42 @@ func (t *TagWriter) tagFLAC(filePath string, track *music.Track) error {
 		}
 	}
 
+	// Always remove existing single-value fields first so a cleared value
+	// removes the field from the file instead of leaving the old one.
+	// Year is stored in both DATE (Vorbis standard) and the widely-used legacy
+	// YEAR field. Write/clear both so the value stays consistent and a stale
+	// field can't resurface when the year is cleared.
+	removeExistingFields(vorbisComment, flacvorbis.FIELD_DATE)
+	removeExistingFields(vorbisComment, "YEAR")
 	if track.Metadata.Year > 0 {
-		removeExistingFields(vorbisComment, flacvorbis.FIELD_DATE)
-		vorbisComment.Add(flacvorbis.FIELD_DATE, strconv.Itoa(track.Metadata.Year))
+		yearStr := strconv.Itoa(track.Metadata.Year)
+		vorbisComment.Add(flacvorbis.FIELD_DATE, yearStr)
+		vorbisComment.Add("YEAR", yearStr)
 	}
 
+	removeExistingFields(vorbisComment, flacvorbis.FIELD_GENRE)
 	if track.Metadata.Genre != "" {
-		removeExistingFields(vorbisComment, flacvorbis.FIELD_GENRE)
 		vorbisComment.Add(flacvorbis.FIELD_GENRE, track.Metadata.Genre)
 	}
 
 	// Additional metadata
+	removeExistingFields(vorbisComment, flacvorbis.FIELD_ISRC)
 	if track.ISRC != "" {
-		removeExistingFields(vorbisComment, flacvorbis.FIELD_ISRC)
 		vorbisComment.Add(flacvorbis.FIELD_ISRC, track.ISRC)
 	}
 
+	removeExistingFields(vorbisComment, flacvorbis.FIELD_TRACKNUMBER)
 	if track.Metadata.TrackNumber > 0 {
-		removeExistingFields(vorbisComment, flacvorbis.FIELD_TRACKNUMBER)
 		vorbisComment.Add(flacvorbis.FIELD_TRACKNUMBER, strconv.Itoa(track.Metadata.TrackNumber))
 	}
 
+	removeExistingFields(vorbisComment, "DISCNUMBER")
 	if track.Metadata.DiscNumber > 0 {
-		removeExistingFields(vorbisComment, "DISCNUMBER")
 		vorbisComment.Add("DISCNUMBER", strconv.Itoa(track.Metadata.DiscNumber))
 	}
 
+	removeExistingFields(vorbisComment, "COMPOSER")
 	if track.Metadata.Composer != "" {
-		removeExistingFields(vorbisComment, "COMPOSER")
 		vorbisComment.Add("COMPOSER", track.Metadata.Composer)
 	}
 
@@ -345,8 +367,8 @@ func (t *TagWriter) tagFLAC(filePath string, track *music.Track) error {
 	}
 
 	// Set additional metadata
+	removeExistingFields(vorbisComment, "VERSION")
 	if track.TitleVersion != "" {
-		removeExistingFields(vorbisComment, "VERSION")
 		vorbisComment.Add("VERSION", track.TitleVersion)
 	}
 	if track.ChromaprintFingerprint != "" {
@@ -357,12 +379,12 @@ func (t *TagWriter) tagFLAC(filePath string, track *music.Track) error {
 		removeExistingFields(vorbisComment, "ACOUSTID_ID")
 		vorbisComment.Add("ACOUSTID_ID", acoustID)
 	}
+	removeExistingFields(vorbisComment, "BPM")
 	if track.Metadata.BPM > 0 {
-		removeExistingFields(vorbisComment, "BPM")
 		vorbisComment.Add("BPM", fmt.Sprintf("%.0f", track.Metadata.BPM))
 	}
+	removeExistingFields(vorbisComment, "REPLAYGAIN_TRACK_GAIN")
 	if track.Metadata.Gain != 0 {
-		removeExistingFields(vorbisComment, "REPLAYGAIN_TRACK_GAIN")
 		vorbisComment.Add("REPLAYGAIN_TRACK_GAIN", fmt.Sprintf("%.2f dB", track.Metadata.Gain))
 	}
 	if track.Album != nil {

--- a/src/music/queue.go
+++ b/src/music/queue.go
@@ -2,6 +2,7 @@ package music
 
 import (
 	"errors"
+	"slices"
 	"time"
 )
 
@@ -15,12 +16,13 @@ type QueueItemType string
 const (
 	// ManualReview indicates a track that needs manual review before import
 	ManualReview QueueItemType = "manual_review"
+	// MissingMetadata indicates a track that is missing a required metadata field
+	// whose absence is not permitted by the import config
+	MissingMetadata QueueItemType = "missing_metadata"
 	// Duplicate indicates a track that is a duplicate of an existing track
 	Duplicate QueueItemType = "duplicate"
 	// FailedImport indicates a track that failed to import
 	FailedImport QueueItemType = "failed_import"
-	// MissingMetadata indicates a track that is missing required metadata
-	MissingMetadata QueueItemType = "missing_metadata"
 	// ExistingLyrics indicates a track that already has lyrics
 	ExistingLyrics QueueItemType = "existing_lyrics"
 	// Lyric404 indicates a track where lyrics were not found (404)
@@ -29,14 +31,29 @@ const (
 	FailedLyrics QueueItemType = "failed_lyrics"
 )
 
-// QueueItem represents an item in the import queue
+// QueueItem represents an item in the import queue. A single item can carry more than one
+// type at once (e.g. a track that is both a Duplicate and MissingMetadata).
 type QueueItem struct {
 	ID        string            `json:"id"`
-	Type      QueueItemType     `json:"type"`
+	Types     []QueueItemType   `json:"types"`
 	Track     *Track            `json:"track"`
 	Timestamp time.Time         `json:"timestamp"`
 	JobID     string            `json:"job_id"`
 	Metadata  map[string]string `json:"metadata"`
+}
+
+// HasType reports whether the item carries the given type.
+func (q QueueItem) HasType(t QueueItemType) bool {
+	return slices.Contains(q.Types, t)
+}
+
+// PrimaryType returns the item's first type, or "" when it has none. It is a convenience for
+// callers (e.g. the lyrics queue) where an item only ever carries a single type.
+func (q QueueItem) PrimaryType() QueueItemType {
+	if len(q.Types) == 0 {
+		return ""
+	}
+	return q.Types[0]
 }
 
 // Queue defines the interface for managing import queue items

--- a/src/music/track.go
+++ b/src/music/track.go
@@ -2,6 +2,7 @@ package music
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -226,17 +227,21 @@ func (t *Track) Pretty() string {
 	return builder.String()
 }
 
-// EnsureMetadataDefaults adds fallback values for missing metadata fields. This function doesn't mean track struct completeness
-func (t *Track) EnsureMetadataDefaults() {
+// EnsureMetadataDefaults adds fallback values for missing metadata fields whose absence is
+// permitted by the per-field flags. Fields that are not permitted are left untouched so that
+// downstream validation can reject the track. The caller (e.g. the importing feature) owns the
+// policy of which fields may be defaulted; pass every flag as true to fully default a track.
+// This function doesn't mean track struct completeness.
+func (t *Track) EnsureMetadataDefaults(artist, album, title, year, genre bool) {
 	// Fallback for missing artist
-	if len(t.Artists) == 0 || t.Artists[0].Artist.Name == "" {
+	if artist && (len(t.Artists) == 0 || t.Artists[0].Artist == nil || t.Artists[0].Artist.Name == "") {
 		t.Artists = []ArtistRole{{
 			Artist: &Artist{ID: "00000000-0000-0000-0000-000000000001", Name: "Unknown Artist", SortName: "Unknown Artist"},
 			Role:   "main",
 		}}
 	}
 	// Fallback for missing album
-	if t.Album == nil || t.Album.Title == "" {
+	if album && (t.Album == nil || t.Album.Title == "") {
 		t.Album = &Album{
 			ID:    "00000000-0000-0000-0000-000000000002",
 			Title: "Unknown Album",
@@ -247,30 +252,53 @@ func (t *Track) EnsureMetadataDefaults() {
 			ReleaseDate: time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC),
 		}
 	}
-	// Fallback for missing year
-	if t.Metadata.Year == 0 {
+	// Fallback for missing title, derived from the file name when available
+	if title && t.Title == "" {
+		t.Title = unknownTitle(t.Path)
+	}
+	// Fallback for missing year (0000)
+	if year && t.Metadata.Year == 0 {
 		t.Metadata.Year = 0000
 	}
 	// Fallback for missing genre
-	if t.Metadata.Genre == "" {
+	if genre && t.Metadata.Genre == "" {
 		t.Metadata.Genre = "Unknown"
 	}
 }
 
-// ValidateRequiredMetadata checks for required metadata fields and returns an error if any are missing
-func (t *Track) ValidateRequiredMetadata() error {
+// unknownTitle builds a fallback title for a track with no title, using the source file
+// name (without extension) when a path is available, e.g. "Unknown Title (song)".
+func unknownTitle(path string) string {
+	if path == "" {
+		return "Unknown Title"
+	}
+	name := filepath.Base(path)
+	name = strings.TrimSuffix(name, filepath.Ext(name))
+	if name == "" {
+		return "Unknown Title"
+	}
+	return fmt.Sprintf("Unknown Title (%s)", name)
+}
+
+// ValidateRequiredMetadata checks for required metadata fields and returns an error listing
+// any that are missing. Fields whose absence is permitted by the per-field flags are not
+// reported; pass every flag as false to require all fields.
+func (t *Track) ValidateRequiredMetadata(artist, album, title, year, genre bool) error {
 	var missingFields []string
-	if len(t.Artists) == 0 || t.Artists[0].Artist.Name == "" {
+	if !artist && (len(t.Artists) == 0 || t.Artists[0].Artist == nil || t.Artists[0].Artist.Name == "") {
 		missingFields = append(missingFields, "Artist")
 	}
-	if t.Album == nil || t.Album.Title == "" {
+	if !album && (t.Album == nil || t.Album.Title == "") {
 		missingFields = append(missingFields, "Album")
 	}
-	if t.Title == "" {
+	if !title && t.Title == "" {
 		missingFields = append(missingFields, "Title")
 	}
-	if t.Metadata.Year == 0 {
+	if !year && t.Metadata.Year == 0 {
 		missingFields = append(missingFields, "Year")
+	}
+	if !genre && t.Metadata.Genre == "" {
+		missingFields = append(missingFields, "Genre")
 	}
 	if len(missingFields) > 0 {
 		return fmt.Errorf("missing required metadata fields: %s", strings.Join(missingFields, ", "))

--- a/views/config/config_form.html
+++ b/views/config/config_form.html
@@ -215,10 +215,36 @@
                        class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
                 <label for="import.always_queue" class="ml-6 text-sm font-medium text-gray-700 dark:text-gray-300">Always queue tracks for review.</label>
               </div>
-              <div class="flex flex-col md:flex-row md:items-center p-3 bg-gray-50/50 dark:bg-gray-700/30 rounded-lg">
-                <input type="checkbox" id="import.allow_missing_metadata" name="import.allow_missing_metadata" value="true" {{if .Config.Import.AllowMissingMetadata}}checked{{end}}
-                       class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
-                <label for="import.allow_missing_metadata" class="ml-6 text-sm font-medium text-gray-700 dark:text-gray-300">Allow tracks without artist or album metadata.</label>
+              <div class="p-3 bg-gray-50/50 dark:bg-gray-700/30 rounded-lg">
+                <p class="text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Allow missing metadata</p>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mb-3">When a field is allowed, missing values are filled with a fallback default on import. Otherwise the track is sent to the review queue.</p>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <div class="flex items-center">
+                    <input type="checkbox" id="import.allow_missing_metadata.artist" name="import.allow_missing_metadata.artist" value="true" {{if .Config.Import.AllowMissingMetadata.Artist}}checked{{end}}
+                           class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                    <label for="import.allow_missing_metadata.artist" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Artist</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input type="checkbox" id="import.allow_missing_metadata.album" name="import.allow_missing_metadata.album" value="true" {{if .Config.Import.AllowMissingMetadata.Album}}checked{{end}}
+                           class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                    <label for="import.allow_missing_metadata.album" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Album</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input type="checkbox" id="import.allow_missing_metadata.title" name="import.allow_missing_metadata.title" value="true" {{if .Config.Import.AllowMissingMetadata.Title}}checked{{end}}
+                           class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                    <label for="import.allow_missing_metadata.title" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Title</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input type="checkbox" id="import.allow_missing_metadata.year" name="import.allow_missing_metadata.year" value="true" {{if .Config.Import.AllowMissingMetadata.Year}}checked{{end}}
+                           class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                    <label for="import.allow_missing_metadata.year" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Year</label>
+                  </div>
+                  <div class="flex items-center">
+                    <input type="checkbox" id="import.allow_missing_metadata.genre" name="import.allow_missing_metadata.genre" value="true" {{if .Config.Import.AllowMissingMetadata.Genre}}checked{{end}}
+                           class="w-5 h-5 text-blue-600 bg-white/50 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600">
+                    <label for="import.allow_missing_metadata.genre" class="ml-3 text-sm font-medium text-gray-700 dark:text-gray-300">Genre</label>
+                  </div>
+                </div>
               </div>
              <div class="p-3 bg-gray-50/50 dark:bg-gray-700/30 rounded-lg">
                <label for="import.duplicates" class="block mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">Duplicate Handling</label>

--- a/views/importing/queue_items.html
+++ b/views/importing/queue_items.html
@@ -1,8 +1,8 @@
 {{if .QueueItems}}
 {{range .QueueItems}}
-<div class="w-full {{if eq .Type "duplicate"}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else if eq .Type "failed_import"}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if eq .Type "missing_metadata"}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} shadow-sm rounded-xl p-4 backdrop-blur-sm mb-4">
+<div class="w-full {{if .IsFailedImport}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if .IsMissingMetadata}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else if .IsDuplicate}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} shadow-sm rounded-xl p-4 backdrop-blur-sm mb-4">
     <div class="flex flex-col space-y-2">
-        <!-- Top row: Title on left, Date + Badge on right -->
+        <!-- Top row: Title on left, Date + Badges on right -->
         <div class="flex items-center justify-between">
             <div class="flex items-center gap-3 flex-1 min-w-0">
               <img src="/import/queue/{{.ID}}/artwork"
@@ -11,42 +11,38 @@
                    onerror="this.style.display='none'">
               <h4 class="text-sm font-semibold text-gray-900 dark:text-white truncate">{{.Track.Title}}</h4>
             </div>
-            <div class="flex items-center space-x-2 ml-2">
+            <div class="flex items-center flex-wrap gap-2 ml-2 justify-end">
                 <span class="text-xs text-gray-500 dark:text-gray-400">{{.Timestamp.Format "Jan 2, 15:04"}}</span>
-                 {{if eq .Type "duplicate"}}
-                  {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                  <span 
-                      class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-violet-500/10 backdrop-blur-md border border-violet-400/30 text-violet-600 dark:text-violet-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                {{if .IsDuplicate}}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-violet-500/10 backdrop-blur-md border border-violet-400/30 text-violet-600 dark:text-violet-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                      Duplicate
-                  </span>
-                  {{else if eq .Type "missing_metadata"}}
-                    {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                    <span 
-                        class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 {{if len .ItemMetadata}}cursor-help{{end}}"
-                         {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                       Missing Metadata
-                    </span>
-                 {{else if eq .Type "failed_import"}}
-                  {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                  <span 
-                      class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                    Duplicate
+                </span>
+                {{end}}
+                {{if .IsMissingMetadata}}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                      Failed Import
-                  </span>
-                 {{else}}
-                  {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                  <span 
-                      class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-blue-500/10 backdrop-blur-md border border-blue-400/30 text-blue-600 dark:text-blue-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                    Missing Metadata
+                </span>
+                {{end}}
+                {{if .IsFailedImport}}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                      Manual Review
-                  </span>
-                 {{end}}
+                    Failed Import
+                </span>
+                {{end}}
+                {{if .IsManualReview}}
+                <span class="inline-flex items-center px-2 py-0.5 rounded-md text-xs font-medium tracking-wider bg-blue-500/10 backdrop-blur-md border border-blue-400/30 text-blue-600 dark:text-blue-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                      {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
+                    Manual Review
+                </span>
+                {{end}}
             </div>
         </div>
 
          <!-- Audio players -->
-         {{if eq .Type "duplicate"}}
+         {{if .IsDuplicate}}
          <div class="flex flex-wrap items-center gap-2">
              <button _="on click toggle .hidden on #player-queue-{{.ID}}"
                  class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
@@ -105,108 +101,59 @@
 
          <!-- Actions - Full width with wrapping -->
          <div class="flex flex-wrap gap-2 justify-start">
-                  {{if eq .Type "duplicate"}}
-                  <!-- For duplicates: Replace/Skip/Delete -->
+                  {{if .ShowReplace}}
                    <button
                        hx-post="/import/queue/{{.ID}}/replace"
                        hx-target="#toast-container"
                        hx-swap="innerHTML"
                        hx-confirm="Replace existing track with this one?"
-                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-md shadow-orange-500/10 hover:shadow-orange-500/20 hover:bg-orange-500/20 dark:hover:bg-orange-500/30">
+                       {{if not .ReplaceEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ReplaceEnabled}}hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-md shadow-orange-500/10 hover:shadow-orange-500/20 hover:bg-orange-500/20 dark:hover:bg-orange-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
                        <i class="fas fa-plus mr-1"></i>
                        Replace
                        <span class="htmx-indicator ml-2">
                          <i class="fas fa-spinner fa-spin"></i>
                        </span>
                    </button>
-                   <button
-                       hx-post="/import/queue/{{.ID}}/cancel"
-                       hx-target="#toast-container"
-                       hx-swap="innerHTML"
-                       hx-confirm="Skip this duplicate track?"
-                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-md shadow-gray-500/10 hover:shadow-gray-500/20 hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                       <i class="fas fa-times mr-1"></i>
-                       Skip
-                       <span class="htmx-indicator ml-2">
-                         <i class="fas fa-spinner fa-spin"></i>
-                       </span>
-                   </button>
-                    <button
-                        hx-post="/import/queue/{{.ID}}/delete"
-                        hx-target="#toast-container"
-                        hx-swap="innerHTML"
-                        hx-confirm="Delete this file from import location?"
-                        class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-md shadow-red-500/10 hover:shadow-red-500/20 hover:bg-red-500/20 dark:hover:bg-red-500/30">
-                        <i class="fas fa-trash mr-1"></i>
-                        Delete
-                        <span class="htmx-indicator ml-2">
-                          <i class="fas fa-spinner fa-spin"></i>
-                        </span>
-                    </button>
-                   {{else if eq .Type "failed_import"}}
-                  <!-- For failed imports: Skip/Delete only -->
-                   <button
-                       hx-post="/import/queue/{{.ID}}/cancel"
-                       hx-target="#toast-container"
-                       hx-swap="innerHTML"
-                       hx-confirm="Skip this failed import track?"
-                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-md shadow-gray-500/10 hover:shadow-gray-500/20 hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                       <i class="fas fa-times mr-1"></i>
-                       Skip
-                       <span class="htmx-indicator ml-2">
-                         <i class="fas fa-spinner fa-spin"></i>
-                       </span>
-                   </button>
-                    <button
-                        hx-post="/import/queue/{{.ID}}/delete"
-                        hx-target="#toast-container"
-                        hx-swap="innerHTML"
-                        hx-confirm="Delete this failed import file from import location?"
-                        class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-md shadow-red-500/10 hover:shadow-red-500/20 hover:bg-red-500/20 dark:hover:bg-red-500/30">
-                        <i class="fas fa-trash mr-1"></i>
-                        Delete
-                        <span class="htmx-indicator ml-2">
-                          <i class="fas fa-spinner fa-spin"></i>
-                        </span>
-                    </button>
-                   {{else}}
-                  <!-- For manual review: Import/Cancel/Delete -->
-                     <button
-                         hx-post="/import/queue/{{.ID}}/import"
-                         hx-target="#toast-container"
-                         hx-swap="innerHTML"
-                           {{if or (eq .Type "failed_import") (.ItemMetadata.error)}}disabled title="Track has errors"{{end}}
-                            class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if or (eq .Type "failed_import") (.ItemMetadata.error)}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{else}}bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-md shadow-green-500/10 hover:-translate-y-0.5 hover:shadow-green-500/20 hover:bg-green-500/20 dark:hover:bg-green-500/30{{end}}">
-                         <i class="fas fa-plus mr-1"></i>
-                         Import
-                         <span class="htmx-indicator ml-2">
-                           <i class="fas fa-spinner fa-spin"></i>
-                         </span>
-                     </button>
-                    <button
-                        hx-post="/import/queue/{{.ID}}/cancel"
-                        hx-target="#toast-container"
-                        hx-swap="innerHTML"
-                        class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-md shadow-red-500/10 hover:shadow-red-500/20 hover:bg-red-500/20 dark:hover:bg-red-500/30">
-                        <i class="fas fa-times mr-1"></i>
-                        Cancel
-                        <span class="htmx-indicator ml-2">
-                          <i class="fas fa-spinner fa-spin"></i>
-                        </span>
-                    </button>
-                    <button
-                        hx-post="/import/queue/{{.ID}}/delete"
-                        hx-target="#toast-container"
-                        hx-swap="innerHTML"
-                        hx-confirm="Delete this file from import location?"
-                        class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-md shadow-red-500/10 hover:shadow-red-500/20 hover:bg-red-500/20 dark:hover:bg-red-500/30">
-                        <i class="fas fa-trash mr-1"></i>
-                        Delete
-                        <span class="htmx-indicator ml-2">
-                          <i class="fas fa-spinner fa-spin"></i>
-                        </span>
-                    </button>
                   {{end}}
+                  {{if .ShowImport}}
+                   <button
+                       hx-post="/import/queue/{{.ID}}/import"
+                       hx-target="#toast-container"
+                       hx-swap="innerHTML"
+                       {{if not .ImportEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ImportEnabled}}bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-md shadow-green-500/10 hover:-translate-y-0.5 hover:shadow-green-500/20 hover:bg-green-500/20 dark:hover:bg-green-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
+                       <i class="fas fa-plus mr-1"></i>
+                       Import
+                       <span class="htmx-indicator ml-2">
+                         <i class="fas fa-spinner fa-spin"></i>
+                       </span>
+                   </button>
+                  {{end}}
+                   <button
+                       hx-post="/import/queue/{{.ID}}/cancel"
+                       hx-target="#toast-container"
+                       hx-swap="innerHTML"
+                       {{if or .IsDuplicate .IsFailedImport}}hx-confirm="Skip this track?"{{end}}
+                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-md shadow-gray-500/10 hover:shadow-gray-500/20 hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
+                       <i class="fas fa-times mr-1"></i>
+                       {{.CancelLabel}}
+                       <span class="htmx-indicator ml-2">
+                         <i class="fas fa-spinner fa-spin"></i>
+                       </span>
+                   </button>
+                   <button
+                       hx-post="/import/queue/{{.ID}}/delete"
+                       hx-target="#toast-container"
+                       hx-swap="innerHTML"
+                       hx-confirm="Delete this file from import location?"
+                       class="inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-md shadow-red-500/10 hover:shadow-red-500/20 hover:bg-red-500/20 dark:hover:bg-red-500/30">
+                       <i class="fas fa-trash mr-1"></i>
+                       Delete
+                       <span class="htmx-indicator ml-2">
+                         <i class="fas fa-spinner fa-spin"></i>
+                       </span>
+                   </button>
              </div>
         </div>
     </div>

--- a/views/importing/queue_items_grouped_album.html
+++ b/views/importing/queue_items_grouped_album.html
@@ -77,7 +77,7 @@
             </summary>
             <div class="mt-3 space-y-2 pl-6 border-l-2 border-gray-200 dark:border-gray-700">
                  {{range $group.Items}}
-                 <div class="{{if eq .Type "duplicate"}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else if eq .Type "failed_import"}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if eq .Type "missing_metadata"}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} rounded-lg p-3 flex flex-col gap-2">
+                 <div class="{{if .IsFailedImport}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if .IsMissingMetadata}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else if .IsDuplicate}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} rounded-lg p-3 flex flex-col gap-2">
                     <div class="flex items-center justify-between">
                          <div class="flex items-center gap-2 flex-1 min-w-0">
                               <img src="/import/queue/{{.ID}}/artwork"
@@ -98,26 +98,26 @@
                          </div>
                         <div class="flex items-center space-x-1">
                             <span class="text-xs text-gray-500 dark:text-gray-400">{{.Timestamp.Format "Jan 2, 15:04"}}</span>
-                              {{if eq .Type "duplicate"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{if .IsDuplicate}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Duplicate
                                 </span>
-                              {{else if eq .Type "failed_import"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-orange-500/10 border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
-                                      {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                                    Failed Import
-                                </span>
-                              {{else if eq .Type "missing_metadata"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{end}}
+                              {{if .IsMissingMetadata}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-500/10 border border-red-400/30 text-red-600 dark:text-red-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                        {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Missing Metadata
                                 </span>
-                              {{else}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{end}}
+                              {{if .IsFailedImport}}
+                                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-orange-500/10 border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                                      {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
+                                    Failed Import
+                                </span>
+                              {{end}}
+                              {{if .IsManualReview}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Manual Review
@@ -126,7 +126,7 @@
                         </div>
                     </div>
                     <!-- Audio players -->
-                    {{if eq .Type "duplicate"}}
+                    {{if .IsDuplicate}}
                     <div class="flex flex-wrap items-center gap-1.5">
                         <button _="on click toggle .hidden on #pa-queue-{{.ID}}"
                             class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
@@ -171,30 +171,24 @@
                     {{end}}
                     <!-- Per-item actions -->
                     <div class="flex flex-wrap gap-1.5">
-                        {{if eq .Type "duplicate"}}
+                        {{if .ShowReplace}}
                         <button hx-post="/import/queue/{{.ID}}/replace" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Replace existing track with this one?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-sm hover:bg-orange-500/20 dark:hover:bg-orange-500/30">
+                            {{if not .ReplaceEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ReplaceEnabled}}hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-sm hover:bg-orange-500/20 dark:hover:bg-orange-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
                             <i class="fas fa-sync mr-1"></i>Replace<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
                         </button>
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Skip this duplicate?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
-                        {{else if eq .Type "failed_import"}}
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Skip this failed import?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
-                        {{else}}
+                        {{end}}
+                        {{if .ShowImport}}
                         <button hx-post="/import/queue/{{.ID}}/import" hx-target="#toast-container" hx-swap="innerHTML"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-sm hover:bg-green-500/20 dark:hover:bg-green-500/30">
+                            {{if not .ImportEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ImportEnabled}}hover:-translate-y-0.5 bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-sm hover:bg-green-500/20 dark:hover:bg-green-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
                             <i class="fas fa-plus mr-1"></i>Import<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
                         </button>
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
                         {{end}}
+                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" {{if or .IsDuplicate .IsFailedImport}}hx-confirm="Skip this track?"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
+                            <i class="fas fa-times mr-1"></i>{{.CancelLabel}}<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
+                        </button>
                         <button hx-post="/import/queue/{{.ID}}/delete" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Delete this file from import location?"
                             class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-sm hover:bg-red-500/20 dark:hover:bg-red-500/30">
                             <i class="fas fa-trash mr-1"></i>Delete<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>

--- a/views/importing/queue_items_grouped_artist.html
+++ b/views/importing/queue_items_grouped_artist.html
@@ -77,7 +77,7 @@
             </summary>
             <div class="mt-3 space-y-2 pl-6 border-l-2 border-gray-200 dark:border-gray-700">
                  {{range $group.Items}}
-                 <div class="{{if eq .Type "duplicate"}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else if eq .Type "failed_import"}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if eq .Type "missing_metadata"}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} rounded-lg p-3 flex flex-col gap-2">
+                 <div class="{{if .IsFailedImport}}bg-orange-500/10 dark:bg-orange-500/10 border border-orange-400/30 dark:border-orange-400/30{{else if .IsMissingMetadata}}bg-red-500/10 dark:bg-red-500/10 border border-red-400/30 dark:border-red-400/30{{else if .IsDuplicate}}bg-violet-500/10 dark:bg-violet-500/10 border border-violet-400/30 dark:border-violet-400/30{{else}}bg-blue-500/10 dark:bg-blue-500/10 border border-blue-400/30 dark:border-blue-400/30{{end}} rounded-lg p-3 flex flex-col gap-2">
                     <div class="flex items-center justify-between">
                          <div class="flex items-center gap-2 flex-1 min-w-0">
                               <img src="/import/queue/{{.ID}}/artwork"
@@ -96,26 +96,26 @@
                          </div>
                         <div class="flex items-center space-x-1">
                             <span class="text-xs text-gray-500 dark:text-gray-400">{{.Timestamp.Format "Jan 2, 15:04"}}</span>
-                              {{if eq .Type "duplicate"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{if .IsDuplicate}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Duplicate
                                 </span>
-                              {{else if eq .Type "failed_import"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
-                                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-orange-500/10 border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
-                                      {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
-                                    Failed Import
-                                </span>
-                              {{else if eq .Type "missing_metadata"}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{end}}
+                              {{if .IsMissingMetadata}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-red-500/10 border border-red-400/30 text-red-600 dark:text-red-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Missing Metadata
                                 </span>
-                              {{else}}
-                                {{ $tooltip := "" }}{{if len .ItemMetadata}}{{range $key, $value := .ItemMetadata}}{{ $tooltip = printf "%s%s: %s\n" $tooltip $key $value }}{{end}}{{end}}
+                              {{end}}
+                              {{if .IsFailedImport}}
+                                <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-orange-500/10 border border-orange-400/30 text-orange-600 dark:text-orange-300 {{if len .ItemMetadata}}cursor-help{{end}}"
+                                      {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
+                                    Failed Import
+                                </span>
+                              {{end}}
+                              {{if .IsManualReview}}
                                 <span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-blue-500/10 border border-blue-400/30 text-blue-600 dark:text-blue-300 {{if len .ItemMetadata}}cursor-help{{end}}"
                                       {{if len .ItemMetadata}}title="{{$tooltip}}" data-tooltip="{{$tooltip}}"{{end}}>
                                     Manual Review
@@ -124,7 +124,7 @@
                         </div>
                     </div>
                     <!-- Audio players -->
-                    {{if eq .Type "duplicate"}}
+                    {{if .IsDuplicate}}
                     <div class="flex flex-wrap items-center gap-1.5">
                         <button _="on click toggle .hidden on #pg-queue-{{.ID}}"
                             class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded text-xs font-medium bg-violet-500/10 border border-violet-400/30 text-violet-600 dark:text-violet-300 hover:bg-violet-500/20 transition-colors">
@@ -169,30 +169,24 @@
                     {{end}}
                     <!-- Per-item actions -->
                     <div class="flex flex-wrap gap-1.5">
-                        {{if eq .Type "duplicate"}}
+                        {{if .ShowReplace}}
                         <button hx-post="/import/queue/{{.ID}}/replace" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Replace existing track with this one?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-sm hover:bg-orange-500/20 dark:hover:bg-orange-500/30">
+                            {{if not .ReplaceEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ReplaceEnabled}}hover:-translate-y-0.5 bg-orange-500/10 backdrop-blur-md border border-orange-400/30 text-orange-600 dark:text-orange-300 shadow-sm hover:bg-orange-500/20 dark:hover:bg-orange-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
                             <i class="fas fa-sync mr-1"></i>Replace<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
                         </button>
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Skip this duplicate?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
-                        {{else if eq .Type "failed_import"}}
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Skip this failed import?"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
-                        {{else}}
+                        {{end}}
+                        {{if .ShowImport}}
                         <button hx-post="/import/queue/{{.ID}}/import" hx-target="#toast-container" hx-swap="innerHTML"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-sm hover:bg-green-500/20 dark:hover:bg-green-500/30">
+                            {{if not .ImportEnabled}}disabled title="{{.BlockReason}}"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo {{if .ImportEnabled}}hover:-translate-y-0.5 bg-green-500/10 backdrop-blur-md border border-green-400/30 text-green-600 dark:text-green-300 shadow-sm hover:bg-green-500/20 dark:hover:bg-green-500/30{{else}}bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 cursor-not-allowed{{end}}">
                             <i class="fas fa-plus mr-1"></i>Import<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
                         </button>
-                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML"
-                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
-                            <i class="fas fa-times mr-1"></i>Skip<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
-                        </button>
                         {{end}}
+                        <button hx-post="/import/queue/{{.ID}}/cancel" hx-target="#toast-container" hx-swap="innerHTML" {{if or .IsDuplicate .IsFailedImport}}hx-confirm="Skip this track?"{{end}}
+                            class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-gray-500/10 backdrop-blur-md border border-gray-400/30 text-gray-600 dark:text-gray-300 shadow-sm hover:bg-gray-500/20 dark:hover:bg-gray-500/30">
+                            <i class="fas fa-times mr-1"></i>{{.CancelLabel}}<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>
+                        </button>
                         <button hx-post="/import/queue/{{.ID}}/delete" hx-target="#toast-container" hx-swap="innerHTML" hx-confirm="Delete this file from import location?"
                             class="inline-flex items-center px-2 py-1 rounded text-xs font-medium tracking-wider transition-all duration-300 ease-out-expo hover:-translate-y-0.5 bg-red-500/10 backdrop-blur-md border border-red-400/30 text-red-600 dark:text-red-300 shadow-sm hover:bg-red-500/20 dark:hover:bg-red-500/30">
                             <i class="fas fa-trash mr-1"></i>Delete<span class="htmx-indicator ml-1"><i class="fas fa-spinner fa-spin"></i></span>


### PR DESCRIPTION
PR Improves the importing queue,  making it possible to have multiple reasons for why a track was queued in a single queue item. It also expands the `missing_metadata` queue type and makes it configurable so that the user can decide weather it wants to let tracks to it's library with/withtout `Title`, `Artist`, `Album`, `Genre` and/or `Year`. 
Defaults for those type have been defined in the domains and added to the configuration feature. 

Additionally this PR removes the defaults value for the download job. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Import settings now support per-field control of missing metadata handling (Artist, Album, Title, Year, Genre).
  * Queue items can now display multiple status types simultaneously (e.g., Duplicate + Missing Metadata).

* **Improvements**
  * Items with missing required metadata are now blocked from import/replace actions (only cancel/delete/skip available).
  * Tag writing improved to prevent stale metadata from persisting in files.

* **Documentation**
  * Updated import configuration and queue behavior documentation to reflect granular metadata controls and multi-type queue items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->